### PR TITLE
cr2hdr.lua: Magic Lantern Dual ISO processing.

### DIFF
--- a/contrib/cr2hdr.lua
+++ b/contrib/cr2hdr.lua
@@ -1,0 +1,79 @@
+--[[
+    Copyright (C) 2015 Till Theato <theato@ttill.de>.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+]]
+--[[
+cr2hdr …
+
+This script …
+
+USAGE
+* require this script from your main lua file
+* …
+]]
+
+local darktable = require "darktable"
+
+-- Tested with darktable 1.6.2
+darktable.configuration.check_version(...,{2,0,2})
+
+local processed_files = {}
+
+function file_imported(event, image)
+    local filename = image.path .. "/" .. image.filename
+    if processed_files[filename] then
+        image.make_group_leader(image)
+        processed_files[filename] = nil
+    end
+end
+
+-- Source: http://lua-users.org/wiki/SplitJoin
+function lines(str)
+  local t = {}
+  local function helper(line) table.insert(t, line) return "" end
+  helper((str:gsub("(.-)\r?\n", helper)))
+  return t
+end
+
+function convert_image(image)
+    if string.sub(image.filename, -3) == "CR2" then
+        local filename = image.path .. "/" .. image.filename
+        local handle = io.popen("cr2hdr " .. filename)
+        local result = handle:read("*a")
+        handle:close()
+        local out_filename = string.gsub(filename, ".CR2", ".DNG")
+        local file = io.open(out_filename)
+        if file then
+            file:close()
+            processed_files[out_filename] = true
+            darktable.database.import(out_filename)
+        else
+            result = lines(result)
+            darktable.print_error(image.filename .. ": cr2hdr failed: " .. result[#result-1])
+        end
+    else
+        darktable.print_error(image.filename .. " is not a Canon RAW.")
+    end
+end
+
+function convert_action_images(shortcut)
+    local images = darktable.gui.action_images
+    for _,image in pairs(images) do
+        convert_image(image)
+    end
+end
+
+darktable.register_event("shortcut", convert_action_images, "Run cr2hdr (Magic Lantern DualISO converter) on ... images")
+darktable.register_event("post-import-image", file_imported)

--- a/contrib/cr2hdr.lua
+++ b/contrib/cr2hdr.lua
@@ -41,7 +41,7 @@ local queue = {}
 local processed_files = {}
 local job
 
-function file_imported(event, image)
+local function file_imported(event, image)
     local filename = image.path .. "/" .. image.filename
     if processed_files[filename] then
         image.make_group_leader(image)
@@ -53,11 +53,11 @@ function file_imported(event, image)
     end
 end
 
-function stop_conversion(job)
+local function stop_conversion(job)
     job.valid = false
 end
 
-function convert_image(image)
+local function convert_image(image)
     if string.sub(image.filename, -3) == "CR2" then
         local filename = image.path .. "/" .. image.filename
         local result = coroutine.yield("RUN_COMMAND", "cr2hdr " .. filename)
@@ -75,7 +75,7 @@ function convert_image(image)
     end
 end
 
-function convert_images()
+local function convert_images()
     if next(queue) == nil then return end
 
     job = darktable.gui.create_job("Dual ISO conversion", true, stop_conversion)
@@ -95,13 +95,13 @@ function convert_images()
     queue = {}
 end
 
-function film_imported(event, film)
+local function film_imported(event, film)
     if darktable.preferences.read("cr2hdr", "onimport", "bool") then
         convert_images()
     end
 end
 
-function convert_action_images(shortcut)
+local function convert_action_images(shortcut)
     queue = darktable.gui.action_images
     convert_images()
 end

--- a/contrib/cr2hdr.lua
+++ b/contrib/cr2hdr.lua
@@ -43,7 +43,7 @@ function file_imported(event, image)
     local filename = image.path .. "/" .. image.filename
     if processed_files[filename] then
         image.make_group_leader(image)
-        processed_files[filename] = nil
+        processed_files[filename] = false
     end
 end
 
@@ -80,6 +80,9 @@ function convert_action_images(shortcut)
             return
         end
     end
+    local success_count = 0
+    for _ in pairs(processed_files) do success_count = success_count + 1 end
+    darktable.print("Dual ISO conversion successful on " .. success_count .. "/" .. #images .. " images.")
     job.valid = false
 end
 


### PR DESCRIPTION
This script automates the steps involved to process an image created with the Magic Lantern Dual ISO module.  Upon invoking the script with a shortcut "cr2hdr" provided by Magic Lantern is run on the selected images. The processed files are imported. They are also made group leaders to hide the original files.

Will make working with Dual ISO a lot easier until #10170 is fixed.