### PR TITLE
Update selection_to_pdf.lua

### DIFF
--- a/official/selection_to_pdf.lua
+++ b/official/selection_to_pdf.lua
@@ -34,7 +34,7 @@ dt.preferences.register
    ("selection_to_pdf","Open with","string",
     "a pdf viewer",
     "Can be an absolute pathname or the tool may be in the PATH",
-    "evince")
+    "xdg-open")
 
 local title_widget = dt.new_widget("entry") {
   placeholder="Title"


### PR DESCRIPTION
xdg-open opens a file in the user's preferred application. You could even remove this preference. This will improve the script for everyone not using evince.