### PR TITLE
Specify location of luarc file in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ lua-scripts
 
 The Lua scripts in this repository are meant to be used together with darktable. Either copy them individually to `~/.config/darktable/lua` (you might have to create that folder) or just copy/symlink the whole repository there. That allows to update all your scripts with a simple call to `git pull`.
 
-To enable one of the scripts you have to add a line like `require "official/hello_world"` which would enable the example script in `official/hello_world.lua`.
+To enable one of the scripts you have to add a line like `require "official/hello_world"` to your `~/.config/darktable/luarc` file which will enable the example script in `official/hello_world.lua` (note the lack of the `.lua` suffix).
 
 Each script includes its own documentation and usage in its header, please refer to them.
 


### PR DESCRIPTION
Update README to show more explicitly how to include a script in darktable.