### PR TITLE
Take care for code in for loop to be run even for the last image.

### DIFF
--- a/official/import_filters.lua
+++ b/official/import_filters.lua
@@ -75,6 +75,7 @@ dt.register_import_filter("prefer raw over jpeg", function(event, images)
     end
 
   end
+  table.remove(images)
 end)
 
 -- vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/official/import_filters.lua
+++ b/official/import_filters.lua
@@ -50,6 +50,7 @@ dt.register_import_filter("prefer raw over jpeg", function(event, images)
   local current_base = ""
   local jpg_indices = {}
   local other_format_found = false
+  table.insert(images, "")
   for i, img in ipairs(images) do
     local extension = img:match("[^.]*$"):upper()
     local base = img:match("^.*[.]")


### PR DESCRIPTION
The problem: If the last image is a jpeg/raw pair, the code to remove the jpeg from the import list is not run since it is the last image. This is solved by adding an empty line at the end of the images array. This entry will be counted as new base and therefore the jpeg removal code will be run one more time. I don't know if this is a good solution but I think it solves the problem without adding complexity. Maybe the empty entry should be removed afterwards, but it seems to work without.