### PR TITLE
Update cr2hdr.lua

### DIFF
--- a/contrib/cr2hdr.lua
+++ b/contrib/cr2hdr.lua
@@ -34,8 +34,8 @@ USAGE
 
 local darktable = require "darktable"
 
--- Tested with darktable 1.6.2
-darktable.configuration.check_version(...,{2,0,2})
+-- Tested with darktable 2.0.1
+darktable.configuration.check_version(...,{2,0,0},{3,0,0})
 
 local queue = {}
 local processed_files = {}


### PR DESCRIPTION
for darktable 2.0