### PR TITLE
[selection_to_pdf ] Added option to rotate portrait images to better fit on the page

### DIFF
--- a/official/selection_to_pdf.lua
+++ b/official/selection_to_pdf.lua
@@ -42,10 +42,16 @@ dt.preferences.register
 local title_widget = dt.new_widget("entry") {
   placeholder="Title"
 }
+
+local autorotate_widget = dt.new_widget("check_button"){
+  label = "rotate portrait images for better fitting", value = false
+}
+
 local widget = dt.new_widget("box") {
   orientation=horizontal,
   dt.new_widget("label"){label = "Title:"},
-  title_widget
+  title_widget,
+  autorotate_widget
 }
 
 local ending = [[
@@ -83,7 +89,7 @@ local function thumbnail(latexfile,i,image,file)
   local ext=string.gsub(file, "(.*)(%..*)", "%2")
   my_write(latexfile,"\\begin{minipage}[b]{"..width.."\\textwidth}\n")
   
-  if image.height > image.width then 
+  if autorotate_widget.value == true and image.height > image.width then 
     my_write(latexfile,"\\includegraphics[angle=90, width=\\textwidth]{{"..filenoext.."}"..ext.."}\\newline\n")
    else
     my_write(latexfile,"\\includegraphics[width=\\textwidth]{{"..filenoext.."}"..ext.."}\\newline\n")

--- a/official/selection_to_pdf.lua
+++ b/official/selection_to_pdf.lua
@@ -82,7 +82,12 @@ local function thumbnail(latexfile,i,image,file)
   local filenoext=string.gsub(file, "(.*)(%..*)", "%1")
   local ext=string.gsub(file, "(.*)(%..*)", "%2")
   my_write(latexfile,"\\begin{minipage}[b]{"..width.."\\textwidth}\n")
-  my_write(latexfile,"\\includegraphics[width=\\textwidth]{{"..filenoext.."}"..ext.."}\\newline\n")
+  
+  if image.height > image.width then 
+    my_write(latexfile,"\\includegraphics[angle=90, width=\\textwidth]{{"..filenoext.."}"..ext.."}\\newline\n")
+   else
+    my_write(latexfile,"\\includegraphics[width=\\textwidth]{{"..filenoext.."}"..ext.."}\\newline\n")
+  end
   my_write(latexfile,"\\centering{"..i..": \\verb|"..title.."|}\n")
   my_write(latexfile,"\\end{minipage}\\quad\n")
 end


### PR DESCRIPTION
I think for "contact sheets" the orientation is not that important. Portrait images waste a lot of space on the sheet. So images will be rotated in latex if image.heigth > image.width. This does not work correctly if images had been rotated using the lighttable rotate buttons. I don't know howto fix this, because there is no type for image.orientation in the lua API?

Best wishes,
Christian