### PR TITLE
Import filters fix

### DIFF
--- a/official/import_filters.lua
+++ b/official/import_filters.lua
@@ -1,6 +1,6 @@
 --[[
     This file is part of darktable,
-    copyright (c) 2015 Tobias Ellinghaus
+    copyright (c) 2015-2016 Tobias Ellinghaus & Christian Mandel
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -50,8 +50,11 @@ dt.register_import_filter("prefer raw over jpeg", function(event, images)
   local current_base = ""
   local jpg_indices = {}
   local other_format_found = false
+
+  -- add dummy image to force processing for the last image
   local last_index
   table.insert(images, "")
+
   for i, img in ipairs(images) do
     local extension = img:match("[^.]*$"):upper()
     local base = img:match("^.*[.]")
@@ -77,7 +80,12 @@ dt.register_import_filter("prefer raw over jpeg", function(event, images)
 
     last_index = i
   end
+
+  -- remove dummy image from list (just to make sure, it works even with keeping
+  -- the dummy but that may break in the future), table.remove(images) does not
+  -- work reliable because it can fail for sparse tables
   images[last_index] = nil
+
 end)
 
 -- vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/official/import_filters.lua
+++ b/official/import_filters.lua
@@ -50,6 +50,7 @@ dt.register_import_filter("prefer raw over jpeg", function(event, images)
   local current_base = ""
   local jpg_indices = {}
   local other_format_found = false
+  local last_index
   table.insert(images, "")
   for i, img in ipairs(images) do
     local extension = img:match("[^.]*$"):upper()
@@ -74,8 +75,9 @@ dt.register_import_filter("prefer raw over jpeg", function(event, images)
       other_format_found = true
     end
 
+    last_index = i
   end
-  table.remove(images)
+  images[last_index] = nil
 end)
 
 -- vim: shiftwidth=2 expandtab tabstop=2 cindent


### PR DESCRIPTION
Fix accidentally deleted first image during import. Lua is very picky about sparse table handling. It is even a difference for different densities of the sparse table. Especially, `table.remove` does only remove the last entry if the table is a “dense” sparse table, for others it will remove the last element of the first contiguous sequence of integer indices (I guess it is even more complicated).