### PR TITLE
Fix for issues #58 and #59 - Issue with exporting RAW images

### DIFF
--- a/contrib/kml_export.lua
+++ b/contrib/kml_export.lua
@@ -30,6 +30,7 @@ WARNING
 This script is only tested with Linux
 
 USAGE
+* require script "official/yield" from your main Lua file in the first line
 * require this script from your main Lua file
 * when choosing file format, pick JPEG or PNG as Google Earth doesn't support other formats
 
@@ -202,7 +203,7 @@ local function create_kml_file(storage, image_table, extra_data)
         -- Creates dir if not exsists
         imageFoldername = "files/"
         local mkdirCommand = "mkdir -p "..exportDirectory.."/"..imageFoldername
-        coroutine.yield("RUN_COMMAND", mkdirCommand) 
+        dt.control.execute(mkdirCommand) 
     end
 
 
@@ -222,8 +223,7 @@ local function create_kml_file(storage, image_table, extra_data)
             --	profiles that might be present in the input and aren't needed in the thumbnail.
 
             local convertToThumbCommand = "convert -size 96x96 "..exported_image.." -resize 92x92 -mattecolor \"#FFFFFF\" -frame 2x2 +profile \"*\" "..exportDirectory.."/"..imageFoldername.."thumb_"..filename..".jpg"
-            -- USE coroutine.yield. It does not block the UI
-            coroutine.yield("RUN_COMMAND", convertToThumbCommand)
+            dt.control.execute(convertToThumbCommand)
         else
             -- Remove exported image if it has no GPS data
             os.remove(exported_image)
@@ -341,7 +341,6 @@ local function create_kml_file(storage, image_table, extra_data)
 -- Compress the files to create a KMZ file
     if ( dt.preferences.read("kml_export","CreateKMZ","bool") == true ) then
        exportDirectory = dt.preferences.read("kml_export","ExportDirectory","string")
-        -- USE coroutine.yield. It does not block the UI
 
         local createKMZCommand = "zip --test --move --junk-paths "
         createKMZCommand = createKMZCommand .."\""..exportDirectory.."/"..exportKMZFilename.."\" "           -- KMZ filename
@@ -358,7 +357,7 @@ local function create_kml_file(storage, image_table, extra_data)
           end
         end
 
-	coroutine.yield("RUN_COMMAND", createKMZCommand)
+	dt.control.execute(createKMZCommand)
     end
 
 -- Open the file with the standard programm    
@@ -370,7 +369,7 @@ local function create_kml_file(storage, image_table, extra_data)
         else
             kmlFileOpenCommand = "xdg-open "..exportDirectory.."/\""..exportKMLFilename.."\""
 	end
-        coroutine.yield("RUN_COMMAND", kmlFileOpenCommand) 
+        dt.control.execute(kmlFileOpenCommand) 
     end
 
 

--- a/contrib/kml_export.lua
+++ b/contrib/kml_export.lua
@@ -222,6 +222,9 @@ local function create_kml_file(storage, image_table, extra_data)
             local convertToThumbCommand = "convert -size 96x96 "..exported_image.." -resize 92x92 -mattecolor \"#FFFFFF\" -frame 2x2 +profile \"*\" "..exportDirectory.."/"..imageFoldername.."thumb_"..filename..".jpg"
             -- USE coroutine.yield. It does not block the UI
             coroutine.yield("RUN_COMMAND", convertToThumbCommand)
+        else
+            -- Remove exported image if it has no GPS data
+            os.remove(exported_image)
         end
 
         local pattern = "[/]?([^/]+)$"

--- a/contrib/kml_export.lua
+++ b/contrib/kml_export.lua
@@ -1,6 +1,7 @@
 --[[
     This file is part of darktable,
     Copyright 2016 by Tobias Jakobs.
+    Copyright 2016 by Erik Augustin.
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -157,6 +158,7 @@ function string.stripAccents( str )
 end
 
 -- Escape XML characters
+-- Keep &amp; first, otherwise it will double escape other characters
 -- https://stackoverflow.com/questions/1091945/what-characters-do-i-need-to-escape-in-xml-documents
 function string.escapeXmlCharacters( str )
 
@@ -248,7 +250,9 @@ local function create_kml_file(storage, image_table, extra_data)
     kml_file = kml_file.."    <description>Exported from darktable</description>\n"
     
     for image,exported_image in pairs(image_table) do
+    -- Extract filename, e.g DSC9784.ARW -> DSC9784
     filename = string.upper(string.gsub(image.filename,"%.%w*", ""))
+    -- Extract extension from exported image (user can choose JPG or PNG), e.g DSC9784.JPG -> .JPG
     extension = string.match(exported_image,"%.%w*$")
 
 	if ((image.longitude and image.latitude) and 
@@ -262,6 +266,7 @@ local function create_kml_file(storage, image_table, extra_data)
             else
                 image_title = image.filename
             end
+            -- Characters should not be escaped in CDATA, but we are using HTML fragment, so we must escape them
             image_description = string.escapeXmlCharacters(image.description)
 
             kml_file = kml_file.."    <name>"..image_title.."</name>\n"            


### PR DESCRIPTION
- Fixed issue with exporting ARW (or any other than JPG format). Simply I strip extension instead of changing it into suffix separated by underscore.
- Removed second call to ImageMagick and I use image generated by darktable. This means that user can choose image format, size and quality. Tested with jpg and png.Tiff is not working because GoogleEarth will not display it.
- Fixed bug with invalid XML when & was used in image.title or description. & is now encoded.
- Changed baloon style to be more user friendly and now it displays title and description.
