### PR TITLE
official/enfuse.lua TODO list

### DIFF
--- a/official/de_DE/LC_MESSAGES/enfuse.po
+++ b/official/de_DE/LC_MESSAGES/enfuse.po
@@ -29,7 +29,7 @@ msgstr "Exportiere Bild %i/%i"
 
 #: enfuse.lua:228
 msgid "enfuse-mp executable found, using it"
-msgstr "enfuse-mp ausführbare Datei gefunden, wird benutzen es"
+msgstr "enfuse-mp ausführbare Datei gefunden, wird verwenden es"
 
 #: enfuse.lua:254
 msgid "exposure mu"
@@ -37,11 +37,11 @@ msgstr "Belichtung mu"
 
 #: enfuse.lua:255
 msgid "center also known as MEAN of Gaussian weighting function (0 <= MEAN <= 1); default: 0.5"
-msgstr "Zentrum auch als Mittel der Gaußschen Gewichtungsfunktion ( 0 <= MEAN < = 1) bekannt ist; Standard: 0.5"
+msgstr "Zentrum auch als Mittel der Gaußschen Gewichtungsfunktion ( 0 <= MEAN < = 1) bekannt; Standard: 0.5"
 
 #: enfuse.lua:265 enfuse.lua:298
 msgid "depth"
-msgstr "Ausmaß"
+msgstr "Farbtiefe"
 
 #: enfuse.lua:266 enfuse.lua:299
 msgid "output image bits per channel"
@@ -49,7 +49,7 @@ msgstr "Ausgangsabbildbits pro Kanal"
 
 #: enfuse.lua:274 enfuse.lua:309
 msgid "Align Images"
-msgstr "Richten Sie Bilder"
+msgstr "Ausrichten der Bilder"
 
 #: enfuse.lua:319
 msgid "gray projector"
@@ -57,7 +57,7 @@ msgstr "grau Projektor"
 
 #: enfuse.lua:320
 msgid "type of grayscale conversion, default = average"
-msgstr "Art der Graustufen -Konvertierung, default = mittel"
+msgstr "Art der Graustufen-Konvertierung, Standard: mittel"
 
 #: enfuse.lua:329
 msgid "contrast window size"
@@ -65,7 +65,7 @@ msgstr "Kontrastfenstergröße"
 
 #: enfuse.lua:330
 msgid "size of box used for contrast detection, >= 3, default 5"
-msgstr "Größe des Kastens für Kontrasterkennung verwendet,> = 3, default 5"
+msgstr "Größe des Kastens, der für die Kontrasterkennung verwendet wird, > = 3, Standard: 5"
 
 #: enfuse.lua:338
 msgid "contrast edge scale"
@@ -73,11 +73,11 @@ msgstr "Kontrastkante Skala"
 
 #: enfuse.lua:339
 msgid "laplacian edge detection, 0 disables, >0 enables, .3 is a good starting value"
-msgstr "Laplace-Kantenerkennung , 0 deaktiviert die Funktion,> 0 ermöglicht, 0,3 ein guter Start"
+msgstr "Laplace-Kantenerkennung, 0 deaktiviert die Funktion, > 0 aktiviert die Funktion, 0,3 ist ein guter Start"
 
 #: enfuse.lua:377
 msgid "Aligning images..."
-msgstr "Ausrichten von Bildern..."
+msgstr "Ausrichten der Bildern..."
 
 #: enfuse.lua:379
 msgid "Image alignment failed"
@@ -97,11 +97,11 @@ msgstr "Starten von enfuse..."
 
 #: enfuse.lua:490 enfuse.lua:556
 msgid "enfuse failed, see terminal output for details"
-msgstr ""
+msgstr "enfuse fehlgeschlagen, siehe Terminal-Ausgabe für Details"
 
 #: enfuse.lua:501 enfuse.lua:567
 msgid "enfuse was successful, resulting image was imported"
-msgstr "enfuse fehlgeschlagen, siehe Terminal-Ausgabe für Details"
+msgstr "enfuse war erfolgreich, resultierendes Bild wurde importiert"
 
 #: enfuse.lua:576
 msgid "Enfuse HDR"

--- a/official/de_DE/LC_MESSAGES/enfuse.po
+++ b/official/de_DE/LC_MESSAGES/enfuse.po
@@ -8,106 +8,105 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-06 00:29-0400\n"
+"POT-Creation-Date: 2016-09-06 23:30-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Bill Ferguson <wpferguson@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: de_DE\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-X-Generator: Poedit 1.5.4\n"
+"X-Generator: Poedit 1.5.4\n"
 "Language: de_DE\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Poedit-KeywordsList: gettext;dgettext:2;dcgettext:2ngettext:1,2;"
 "dngettext:2,3\n"
 "X-Poedit-Basepath: .\n"
 
-#: enfuse.lua:134
+#: enfuse.lua:217
 #, lua-format
 msgid "Export Image %i/%i"
 msgstr "Exportiere Bild %i/%i"
 
-#: enfuse.lua:142
+#: enfuse.lua:228
 msgid "enfuse-mp executable found, using it"
-msgstr "enfuse -mp ausführbare Datei gefunden, wird benutzen es"
+msgstr "enfuse-mp ausführbare Datei gefunden, wird benutzen es"
 
-#: enfuse.lua:162
+#: enfuse.lua:254
 msgid "exposure mu"
 msgstr "Belichtung mu"
 
-#: enfuse.lua:163
+#: enfuse.lua:255
 msgid "center also known as MEAN of Gaussian weighting function (0 <= MEAN <= 1); default: 0.5"
 msgstr "Zentrum auch als Mittel der Gaußschen Gewichtungsfunktion ( 0 <= MEAN < = 1) bekannt ist; Standard: 0.5"
 
-#: enfuse.lua:171 enfuse.lua:206
+#: enfuse.lua:265 enfuse.lua:298
 msgid "depth"
 msgstr "Ausmaß"
 
-#: enfuse.lua:172 enfuse.lua:207
+#: enfuse.lua:266 enfuse.lua:299
 msgid "output image bits per channel"
 msgstr "Ausgangsabbildbits pro Kanal"
 
-#: enfuse.lua:182 enfuse.lua:240
+#: enfuse.lua:274 enfuse.lua:309
 msgid "Align Images"
 msgstr "Richten Sie Bilder"
 
-#: enfuse.lua:213
+#: enfuse.lua:319
 msgid "gray projector"
 msgstr "grau Projektor"
 
-#: enfuse.lua:214
+#: enfuse.lua:320
 msgid "type of grayscale conversion, default = average"
 msgstr "Art der Graustufen -Konvertierung, default = mittel"
 
-#: enfuse.lua:220
+#: enfuse.lua:329
 msgid "contrast window size"
 msgstr "Kontrastfenstergröße"
 
-#: enfuse.lua:221
+#: enfuse.lua:330
 msgid "size of box used for contrast detection, >= 3, default 5"
 msgstr "Größe des Kastens für Kontrasterkennung verwendet,> = 3, default 5"
 
-#: enfuse.lua:227
+#: enfuse.lua:338
 msgid "contrast edge scale"
 msgstr "Kontrastkante Skala"
 
-#: enfuse.lua:228
+#: enfuse.lua:339
 msgid "laplacian edge detection, 0 disables, >0 enables, .3 is a good starting value"
 msgstr "Laplace-Kantenerkennung , 0 deaktiviert die Funktion,> 0 ermöglicht, 0,3 ein guter Start"
 
-#: enfuse.lua:368
+#: enfuse.lua:377
 msgid "Aligning images..."
 msgstr "Ausrichten von Bildern..."
 
-#: enfuse.lua:370
+#: enfuse.lua:379
 msgid "Image alignment failed"
 msgstr "Bildausrichtung ist fehlgeschlagen"
 
-#: enfuse.lua:389
+#: enfuse.lua:398
 msgid "No aligned images found"
 msgstr "Keine ausgerichteten Bilder gefunden"
 
-#: enfuse.lua:406
-msgid "no suitable images selected, nothing to do for enfuse"
-msgstr "keine geeigneten Bilder ausgewählt, nichts für enfuse zu tun"
+#: enfuse.lua:405 enfuse.lua:422
+msgid "not enough suitable images selected, nothing to do for enfuse"
+msgstr "nicht genug geeignete Bilder ausgewählt, nichts für enfuse zu tun"
 
-#: enfuse.lua:471 enfuse.lua:535
+#: enfuse.lua:488 enfuse.lua:554
 msgid "Launching enfuse..."
 msgstr "Starten von enfuse..."
 
-#: enfuse.lua:473 enfuse.lua:537
+#: enfuse.lua:490 enfuse.lua:556
 msgid "enfuse failed, see terminal output for details"
+msgstr ""
+
+#: enfuse.lua:501 enfuse.lua:567
+msgid "enfuse was successful, resulting image was imported"
 msgstr "enfuse fehlgeschlagen, siehe Terminal-Ausgabe für Details"
 
-#: enfuse.lua:484 enfuse.lua:548
-msgid "enfuse was successful, resulting image was imported"
-msgstr "enfuse erfolgreich war, wurde resultierende Bild importiert"
-
-#: enfuse.lua:554
+#: enfuse.lua:576
 msgid "Enfuse HDR"
 msgstr "Enfuse HDR"
 
-#: enfuse.lua:555
+#: enfuse.lua:577
 msgid "Enfuse Focus Stack"
 msgstr "Enfuse Fokus Stapel"

--- a/official/de_DE/LC_MESSAGES/enfuse.po
+++ b/official/de_DE/LC_MESSAGES/enfuse.po
@@ -1,0 +1,93 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: enfuse\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-08-30 01:02-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Bill Ferguson <wpferguson@gmail.com>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: de_DE\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+X-Generator: Poedit 1.5.4\n"
+"Language: de_DE\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-KeywordsList: gettext;dgettext:2;dcgettext:2ngettext:1,2;"
+"dngettext:2,3\n"
+"X-Poedit-Basepath: .\n"
+
+#: enfuse.lua:135
+#, lua-format
+msgid "Export Image %i/%i"
+msgstr "Exportiere Bild %i/%i"
+
+#: enfuse.lua:143
+msgid "enfuse-mp executable found, using it"
+msgstr "enfuse -mp ausführbare Datei gefunden, wird benutzen es"
+
+#: enfuse.lua:164
+msgid "center also known as MEAN of Gaussian weighting function (0 <= MEAN <= 1); default: 0.5"
+msgstr "Zentrum auch als Mittel der Gaußschen Gewichtungsfunktion ( 0 <= MEAN < = 1) bekannt ist; Standard: 0.5"
+
+#: enfuse.lua:173 enfuse.lua:208
+msgid "output image bits per channel"
+msgstr "Ausgangsabbildbits pro Kanal"
+
+#: enfuse.lua:183 enfuse.lua:241
+msgid "Align Images"
+msgstr "Richten Sie Bilder"
+
+#: enfuse.lua:215
+msgid "type of grayscale conversion, default = average"
+msgstr "Art der Graustufen -Konvertierung, default = mittel"
+
+#: enfuse.lua:222
+msgid "size of box used for contrast detection, >= 3, default 5"
+msgstr "Größe des Kastens für Kontrasterkennung verwendet,> = 3, default 5"
+
+#: enfuse.lua:229
+msgid "laplacian edge detection, 0 disables, >0 enables, .3 is a good starting value"
+msgstr "Laplace-Kantenerkennung , 0 deaktiviert die Funktion,> 0 ermöglicht, 0,3 ein guter Start"
+
+#: enfuse.lua:369
+msgid "Aligning images..."
+msgstr "Ausrichten von Bildern..."
+
+#: enfuse.lua:371
+msgid "Image alignment failed"
+msgstr "Bildausrichtung ist fehlgeschlagen"
+
+#: enfuse.lua:390
+msgid "No aligned images found"
+msgstr "Keine ausgerichteten Bilder gefunden"
+
+#: enfuse.lua:407
+msgid "no suitable images selected, nothing to do for enfuse"
+msgstr "keine geeigneten Bilder ausgewählt, nichts für enfuse zu tun"
+
+#: enfuse.lua:456 enfuse.lua:533
+msgid "Launching enfuse..."
+msgstr "Starten von enfuse..."
+
+#: enfuse.lua:458 enfuse.lua:535
+msgid "enfuse failed, see terminal output for details"
+msgstr "enfuse fehlgeschlagen, siehe Terminal-Ausgabe für Details"
+
+#: enfuse.lua:479 enfuse.lua:556
+msgid "enfuse was successful, resulting image was imported"
+msgstr "enfuse erfolgreich war, wurde resultierende Bild importiert"
+
+#: enfuse.lua:562
+msgid "Enfuse HDR"
+msgstr "Enfuse HDR"
+
+#: enfuse.lua:563
+msgid "Enfuse Focus Stack"
+msgstr "Enfuse Fokus Stapel"

--- a/official/de_DE/LC_MESSAGES/enfuse.po
+++ b/official/de_DE/LC_MESSAGES/enfuse.po
@@ -32,8 +32,8 @@ msgid "enfuse-mp executable found, using it"
 msgstr "enfuse-mp ausführbare Datei gefunden, wird verwenden es"
 
 #: enfuse.lua:254
-msgid "exposure mu"
-msgstr "Belichtung mu"
+msgid "exposure-mu"
+msgstr "Belichtung-mu"
 
 #: enfuse.lua:255
 msgid "center also known as MEAN of Gaussian weighting function (0 <= MEAN <= 1); default: 0.5"

--- a/official/de_DE/LC_MESSAGES/enfuse.po
+++ b/official/de_DE/LC_MESSAGES/enfuse.po
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: enfuse\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-08-30 01:02-0400\n"
+"POT-Creation-Date: 2016-09-06 00:29-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Bill Ferguson <wpferguson@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -23,71 +23,91 @@ X-Generator: Poedit 1.5.4\n"
 "dngettext:2,3\n"
 "X-Poedit-Basepath: .\n"
 
-#: enfuse.lua:135
+#: enfuse.lua:134
 #, lua-format
 msgid "Export Image %i/%i"
 msgstr "Exportiere Bild %i/%i"
 
-#: enfuse.lua:143
+#: enfuse.lua:142
 msgid "enfuse-mp executable found, using it"
 msgstr "enfuse -mp ausführbare Datei gefunden, wird benutzen es"
 
-#: enfuse.lua:164
+#: enfuse.lua:162
+msgid "exposure mu"
+msgstr "Belichtung mu"
+
+#: enfuse.lua:163
 msgid "center also known as MEAN of Gaussian weighting function (0 <= MEAN <= 1); default: 0.5"
 msgstr "Zentrum auch als Mittel der Gaußschen Gewichtungsfunktion ( 0 <= MEAN < = 1) bekannt ist; Standard: 0.5"
 
-#: enfuse.lua:173 enfuse.lua:208
+#: enfuse.lua:171 enfuse.lua:206
+msgid "depth"
+msgstr "Ausmaß"
+
+#: enfuse.lua:172 enfuse.lua:207
 msgid "output image bits per channel"
 msgstr "Ausgangsabbildbits pro Kanal"
 
-#: enfuse.lua:183 enfuse.lua:241
+#: enfuse.lua:182 enfuse.lua:240
 msgid "Align Images"
 msgstr "Richten Sie Bilder"
 
-#: enfuse.lua:215
+#: enfuse.lua:213
+msgid "gray projector"
+msgstr "grau Projektor"
+
+#: enfuse.lua:214
 msgid "type of grayscale conversion, default = average"
 msgstr "Art der Graustufen -Konvertierung, default = mittel"
 
-#: enfuse.lua:222
+#: enfuse.lua:220
+msgid "contrast window size"
+msgstr "Kontrastfenstergröße"
+
+#: enfuse.lua:221
 msgid "size of box used for contrast detection, >= 3, default 5"
 msgstr "Größe des Kastens für Kontrasterkennung verwendet,> = 3, default 5"
 
-#: enfuse.lua:229
+#: enfuse.lua:227
+msgid "contrast edge scale"
+msgstr "Kontrastkante Skala"
+
+#: enfuse.lua:228
 msgid "laplacian edge detection, 0 disables, >0 enables, .3 is a good starting value"
 msgstr "Laplace-Kantenerkennung , 0 deaktiviert die Funktion,> 0 ermöglicht, 0,3 ein guter Start"
 
-#: enfuse.lua:369
+#: enfuse.lua:368
 msgid "Aligning images..."
 msgstr "Ausrichten von Bildern..."
 
-#: enfuse.lua:371
+#: enfuse.lua:370
 msgid "Image alignment failed"
 msgstr "Bildausrichtung ist fehlgeschlagen"
 
-#: enfuse.lua:390
+#: enfuse.lua:389
 msgid "No aligned images found"
 msgstr "Keine ausgerichteten Bilder gefunden"
 
-#: enfuse.lua:407
+#: enfuse.lua:406
 msgid "no suitable images selected, nothing to do for enfuse"
 msgstr "keine geeigneten Bilder ausgewählt, nichts für enfuse zu tun"
 
-#: enfuse.lua:456 enfuse.lua:533
+#: enfuse.lua:471 enfuse.lua:535
 msgid "Launching enfuse..."
 msgstr "Starten von enfuse..."
 
-#: enfuse.lua:458 enfuse.lua:535
+#: enfuse.lua:473 enfuse.lua:537
 msgid "enfuse failed, see terminal output for details"
 msgstr "enfuse fehlgeschlagen, siehe Terminal-Ausgabe für Details"
 
-#: enfuse.lua:479 enfuse.lua:556
+#: enfuse.lua:484 enfuse.lua:548
 msgid "enfuse was successful, resulting image was imported"
 msgstr "enfuse erfolgreich war, wurde resultierende Bild importiert"
 
-#: enfuse.lua:562
+#: enfuse.lua:554
 msgid "Enfuse HDR"
 msgstr "Enfuse HDR"
 
-#: enfuse.lua:563
+#: enfuse.lua:555
 msgid "Enfuse Focus Stack"
 msgstr "Enfuse Fokus Stapel"

--- a/official/enfuse.lua
+++ b/official/enfuse.lua
@@ -1,7 +1,7 @@
 --[[
     This file is part of darktable,
     copyright (c) 2016 Tobias Ellinghaus
-    updated 2016 Bill Ferguson
+    copyright (c) 2016 Bill Ferguson
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -73,7 +73,7 @@
     * 20160828 - Bill Ferguson 
       * Since enfuse can't process raw images, converted it to a storage so that raws can be converted
         and processed.  Named it Enfuse HDR
-      * Added another storage to take advantage of enfuse's ability to process focus stack images
+      * Added another storage to take advantage of enfuse's ability to process focus stack images, Enfuse Focus Stack
       * Fixed TODO - find a less stupid way to make sure the float value of exposure_mu gets turned into a string 
         with a decimal point instead of a comma in some languages
       * Fixed TODO - make the output filename unique so you can use it more than once per filmroll

--- a/official/enfuse.lua
+++ b/official/enfuse.lua
@@ -26,7 +26,7 @@
     * two new storage options are created, Enfuse HDR and Enfuse Focus Stack
     * Enfuse HDR
       * select the bracketed images to use for the hdr
-      * adjust exposure mu to change the brightness of the output image
+      * adjust exposure-mu to change the brightness of the output image
       * select bit depth of the output image
       * if align_image_stack is installed, an option to align the images is 
         available.  Unless you shot your images from a rock steady tripod you
@@ -251,7 +251,7 @@ local hdr_widgets = {}
 -- exposure-mu
 local exposure_mu = dt.new_widget("slider")
 {
-  label = _("exposure mu"),
+  label = _("exposure-mu"),
   tooltip = _("center also known as MEAN of Gaussian weighting function (0 <= MEAN <= 1); default: 0.5"),
   hard_min = 0,
   hard_max = 1,

--- a/official/enfuse.lua
+++ b/official/enfuse.lua
@@ -1,6 +1,7 @@
 --[[
     This file is part of darktable,
     copyright (c) 2016 Tobias Ellinghaus
+    updated 2016 Bill Ferguson
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -16,25 +17,92 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 --[[
-RUN ENFUSE ON THE SELECTED IMAGES
-This script uses enfuse to merge the selected images into one HDR and imports the result.
-It only works on ldr images (like, JPEG).
+    enfuse - export the selected images and run enfuse in one of two modes
+    * Enfuse HDR - combine the exported images into a single HDR image
+    * Enfuse Focus Stack - Combine a set of focus stack images into a single image
 
-USAGE
-* require this script from your main lua file
-* it creates a new lighttable module
+    USAGE
+    * require this script from your main lua file
+    * two new storage options are created, Enfuse HDR and Enfuse Focus Stack
+    * Enfuse HDR
+      * select the bracketed images to use for the hdr
+      * adjust exposure mu to change the brightness of the output image
+      * select bit depth of the output image
+      * if align_image_stack is installed, an option to align the images is 
+        available.  Unless you shot your images from a rock steady tripod you
+        should probably select this.
+      * choose the format and bit depth of the export
+      * NOTE: You might want to specify a smaller size, jpg, and 8 bit to test
+        the hdr output until you find the right combination, then export at full
+        resolution with the desired format and depth.
+      * click export
+      * the resulting tif image will be imported.  The filename will consist of the
+        individual filenames combined with hdr, i.e. 7D_1234-7D_1235-7D_1236-hdr.tif
+    * Enfuse Focus Stack
+      * select the focus stack images that need to be combined
+      * select bit depth of the output image
+      * if align_image_stack is installed, an option to align the images is 
+        available.  Unless you shot your images from a rock steady tripod you
+        should probably select this.
+      * choose the format and bit depth of the export
+      * NOTE: You might want to specify a smaller size, jpg, and 8 bit to test
+        the stack output until you find the right combination, then export at full
+        resolution with the desired format and depth.
+      * click export
+      * the resulting tif image will be imported.  The filename will consist of the
+        first and last filenames combined with stack, i.e. 7D_1234-7D_1236-stack.tif
+      * gray projector, contrast window size, and contrast edge scale can be adjusted
+        to fine tune the output as explained in Pat David's blog post
+        http://blog.patdavid.net/2013/01/focus-stacking-macro-photos-enfuse.html
 
-TODO
-* remember the exposure_mu value in config when the slider is moved
-* make the output filename unique so you can use it more than once per filmroll
-* find a less stupid way to make sure the float value of exposure_mu gets turned into a string
-  with a decimal point instead of a comma in some languages
-* export images that are not ldr and remove them afterwards
+
+    ADDITIONAL SOFTWARE NEEDED FOR THIS SCRIPT
+    * enfuse - http://enblend.sourceforge.net
+    * align_image_stack - optional, part of hugin - http://hugin.sourceforge.net
+
+    CAVEATS
+    * No alignment is done on the images by default.  If align_image_stack is installed, an
+      option to align the images is available.  Image alignment adds more time to the processing.
+      Unless the images were taken using a rock steady tripod, aligning is recommended for best results.
+    * Exporting 8 bit jpgs and specifying a 32 bit tif as output gives some interesting colors
+    * Exporting 3 28MB raws to 16 bit tifs and specifying a 16 bit hdr tif takes 2+ minutes to 
+      generate an hdr on a fast machine.  Focus stacking takes longer.  These numbers assume using 
+      the single thread version of enfuse.  enfuse-mp gives much better results.
+
+    TODO
+    * remember the exposure_mu value in config when the slider is moved
+
+    CHANGES
+    * 20160828 - Bill Ferguson 
+      * Since enfuse can't process raw images, converted it to a storage so that raws can be converted
+        and processed.  Named it Enfuse HDR
+      * Added another storage to take advantage of enfuse's ability to process focus stack images
+      * Fixed TODO - find a less stupid way to make sure the float value of exposure_mu gets turned into a string 
+        with a decimal point instead of a comma in some languages
+      * Fixed TODO - make the output filename unique so you can use it more than once per filmroll
+      * Fixed TODO - export images that are not ldr and remove them afterwards
+      * TODO - save exposure-mu value when changed.  The value gets saved when the storage is executed.  It does not 
+        get saved every time the slider is moved.  
+      * Added German message translations
+      * Check for the multiprocessor version of enfuse and use it if installed.  On my system the mp version is 5 - 6 
+        times faster (i7-6820HK CPU @ 2.70GHz)
+
+    * 20160829 - Bill Ferguson
+      * Added an option to align images using align_image_stack, part of the hugin project, if installed.
 ]]
 
 local dt = require "darktable"
+local gettext = dt.gettext
+local enfuse_executable = "enfuse"
 
 dt.configuration.check_version(...,{3,0,0})
+
+-- Tell gettext where to find the .mo file translating messages for a particular domain
+gettext.bindtextdomain("enfuse",dt.configuration.config_dir.."/lua/")
+
+local function _(msgid)
+    return gettext.dgettext("enfuse", msgid)
+end
 
 -- thanks Tobias Jakobs for this function (taken from contrib/hugin.lua)
 local function checkIfBinExists(bin)
@@ -52,9 +120,32 @@ local function checkIfBinExists(bin)
   return ret
 end
 
--- add a new lib
+-- take care of the case where a decimal point is replaced by a comma in some locales
+local function fixSliderFloat(float_str)
+  if string.match(float_str,"[,.]") then 
+    local characteristic, mantissa = string.match(float_str, "(%d+)[,.](%d+)")
+    float_str = characteristic .. '.' .. mantissa
+  end
+  return float_str
+end
+
+-- print status while exporting images
+local function show_status(storage, image, format, filename,
+  number, total, high_quality, extra_data)
+    dt.print(string.format(_("Export Image %i/%i"), number, total))
+end
+
 -- is enfuse installed?
 local enfuse_installed = checkIfBinExists("enfuse")
+
+-- check for the parallel version and use it if it's installed
+if enfuse_installed and checkIfBinExists("enfuse-mp") then
+  dt.print_error(_("enfuse-mp executable found, using it"))
+  enfuse_executable = "enfuse-mp"
+end
+
+-- check for align_image_stack so we can offer to align the images if desired
+local can_align = checkIfBinExists("align_image_stack")
 
 -- initialize exposure_mu value and depth setting in config to sane defaults (would be 0 otherwise)
 if dt.preferences.read("enfuse", "depth", "integer") == 0 then
@@ -62,11 +153,15 @@ if dt.preferences.read("enfuse", "depth", "integer") == 0 then
   dt.preferences.write("enfuse", "exposure_mu", "float", 0.5)
 end
 
--- set up some widgets, initialized from config
+if dt.preferences.read("enfusestack", "depth", "integer") == 0 then
+  dt.preferences.write("enfusestack", "depth", "integer", 2)
+end
+
+-- set up some hdr widgets, initialized from config
 local exposure_mu = dt.new_widget("slider")
 {
   label = "exposure mu",
-  tooltip = "center also known as MEAN of Gaussian weighting function (0 <= MEAN <= 1); default: 0.5",
+  tooltip = _("center also known as MEAN of Gaussian weighting function (0 <= MEAN <= 1); default: 0.5"),
   hard_min = 0,
   hard_max = 1,
   value = dt.preferences.read("enfuse", "exposure_mu", "float")
@@ -75,100 +170,395 @@ local exposure_mu = dt.new_widget("slider")
 local depth = dt.new_widget("combobox")
 {
   label = "depth",
-  tooltip = "the number of bits per channel of the output image",
-  value = dt.preferences.read("enfuse", "depth", "integer"),
-  changed_callback = function(w) dt.preferences.write("enfuse", "depth", "integer", w.selected) end,
-  "8", "16", "32"
+  tooltip = _("output image bits per channel"),
+  value = dt.preferences.read("enfuse", "depth", "integer"), "8", "16", "32"
 }
 
--- ... and tell dt about it all
-dt.register_lib(
-  "enfuse",                                                                    -- plugin name
-  "enfuse",                                                                    -- name
-  true,                                                                        -- expandable
-  false,                                                                       -- resetable
-  {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 100}},   -- containers
-  dt.new_widget("box")                                                         -- widget
+local hdr_align
+local hdr_widget
+
+if can_align then 
+  hdr_align = dt.new_widget("check_button")
+  {
+    label = _("Align Images"),
+    value = false
+  }
+
+  hdr_widget = dt.new_widget("box")                                                         -- widget
   {
     orientation = "vertical",
-    sensitive = enfuse_installed,
     exposure_mu,
     depth,
-    dt.new_widget("button")
-    {
-      label = enfuse_installed and "run enfuse" or "enfuse not installed",
-      clicked_callback = function (_)
-        -- remember exposure_mu
-        -- TODO: find a way to save it whenever the value changes
-        local mu = exposure_mu.value
-        dt.preferences.write("enfuse", "exposure_mu", "float", mu)
+    hdr_align
+  }
+else
+  hdr_widget = dt.new_widget("box")                                                         -- widget
+  {
+    orientation = "vertical",
+    exposure_mu,
+    depth
+  }
+end
 
-        -- create a temp response file
-        local response_file = os.tmpname()
-        local f = io.open(response_file, "w")
-        if not f then
-          dt.print("error writing to `"..response_file.."'")
-          os.remove(response_file)
-          return
-        end
+-- set up focus stack widgets
 
-        -- add all filenames to the response file
-        local cnt = 0
-        local n_skipped = 0
-        local target_dir
-        for _, i in ipairs(dt.gui.action_images) do
-          -- only use ldr files as enfuse can't open raws. alternatively we could export raws that we encounter
-          if i.is_ldr then
-            cnt = cnt + 1
-            f:write(i.path.."/"..i.filename.."\n")
-            target_dir = i.path
-          else
-            dt.print("skipping "..i.filename)
-            n_skipped = n_skipped + 1
-          end
-        end
-        f:close()
-        -- bail out if there is nothing to do
-        if cnt == 0 then
-          dt.print("no suitable images selected, nothing to do for enfuse")
-          os.remove(response_file)
-          return
-        end
-        if n_skipped == 1 then
-          dt.print(n_skipped.." image skipped")
-        elseif n_skipped > 1 then
-          dt.print(n_skipped.." images skipped")
-        end
+local stack_depth = dt.new_widget("combobox")
+{
+  label = "depth",
+  tooltip = _("output image bits per channel"),
+  value = dt.preferences.read("enfusestack", "depth", "integer") or 2, "8", "16", "32"
+}
 
-        -- call enfuse on the response file
-        -- TODO: find something nicer
-        local ugly_decimal_point_hack = string.gsub(string.format("%.04f", mu), ",", ".")
-        -- TODO: make filename unique
-        local output_image = target_dir.."/enfuse.tiff"
-        local command = "enfuse --depth "..depth.value.." --exposure-mu "..ugly_decimal_point_hack
-                        .." -o \""..output_image.."\" \"@"..response_file.."\""
-        if dt.control.execute( command) > 0 then
-          dt.print("enfuse failed, see terminal output for details")
-          os.remove(response_file)
-          return
-        end
+local gray_projector = dt.new_widget("combobox")
+{
+  label = "gray projector",
+  tooltip = _("type of grayscale conversion, default = average"),
+  value = 1, "average", "l-star"
+}
 
-        -- remove the response file
+local contrast_window = dt.new_widget("combobox")
+{
+  label = "contrast window size",
+  tooltip = _("size of box used for contrast detection, >= 3, default 5"),
+  value = 3, "3", "4", "5", "6", "7", "8", "9"
+}
+
+local contrast_edge = dt.new_widget("slider")
+{
+  label = "contrast edge scale",
+  tooltip = _("laplacian edge detection, 0 disables, >0 enables, .3 is a good starting value"),
+  hard_min = 0,
+  hard_max = 1,
+  value = 0
+}
+
+local stack_align
+local stack_widget
+
+if can_align then
+  stack_align = dt.new_widget("check_button")
+  {
+    label = _("Align Images"),
+    value = false
+  }
+
+  stack_widget = dt.new_widget("box")
+  {
+    orientation = "vertical",
+    stack_depth,
+    stack_align,
+    gray_projector,
+    contrast_window,
+    contrast_edge
+  }
+else
+  stack_widget = dt.new_widget("box")
+  {
+    orientation = "vertical",
+    stack_depth,
+    gray_projector,
+    contrast_window,
+    contrast_edge
+  }
+end
+
+local function split_filepath(str)
+  local result = {}
+  -- Thank you Tobias Jakobs for the awesome regular expression, which I tweaked a little
+  result["path"], result["filename"], result["basename"], result["filetype"] = string.match(str, "(.-)(([^\\/]-)%.?([^%.\\/]*))$")
+  return result
+end
+
+local function get_path(str)
+  local parts = split_filepath(str)
+  return parts["path"]
+end
+
+local function get_filename(str)
+  local parts = split_filepath(str)
+  return parts["filename"]
+end
+
+local function get_basename(str)
+  local parts = split_filepath(str)
+  return parts["basename"]
+end
+
+local function get_filetype(str)
+  local parts = split_filepath(str)
+  return parts["filetype"]
+end
+
+-- Thanks Tobias Jakobs for the idea and the correction
+local function checkIfFileExists(filepath)
+  local file = io.open(filepath,"r")
+  local ret
+  if file ~= nil then 
+    io.close(file) 
+    dt.print_error("true checkIfFileExists: "..filepath)
+    ret = true
+  else 
+    dt.print_error(filepath.." not found")
+    ret = false
+  end
+  return ret
+end
+
+local function filename_increment(filepath)
+
+  -- break up the filepath into parts
+  local path = get_path(filepath)
+  local basename = get_basename(filepath)
+  local filetype = get_filetype(filepath)
+
+  -- check to see if we've incremented before
+  local increment = string.match(basename, "_(%d-)$")
+
+  if increment then
+    -- we do 2 digit increments so make sure we didn't grab part of the filename
+    if string.len(increment) > 2 then
+      -- we got the filename so set the increment to 01
+      increment = "01"
+    else
+      increment = string.format("%02d", tonumber(increment) + 1)
+      basename = string.gsub(basename, "_(%d-)$", "")
+    end
+  else
+    increment = "01"
+  end
+  local incremented_filepath = path .. basename .. "_" .. increment .. "." .. filetype
+
+  dt.print_error("original file was " .. filepath)
+  dt.print_error("incremented file is " .. incremented_filepath)
+
+  return incremented_filepath
+end
+
+local function sanitize_filename(filepath)
+  local path = get_path(filepath)
+  local basename = get_basename(filepath)
+  local filetype = get_filetype(filepath)
+
+  local sanitized = string.gsub(basename, " ", "\\ ")
+
+  return path .. sanitized .. "." .. filetype
+end
+
+-- assemble a list of the files to send to enfuse.  If desired, align the files first
+local function build_response_file(image_table, will_align)
+
+  -- create a temp response file
+  local response_file = os.tmpname()
+  local f = io.open(response_file, "w")
+  if not f then
+     os.remove(response_file)
+    return
+  end
+
+  local cnt = 0
+
+  -- do the alignment first, if requested
+  if will_align then
+    local align_img_list = ""
+    for img, exp_img in pairs(image_table) do
+      cnt = cnt + 1
+      align_img_list = align_img_list .. " " .. sanitize_filename(exp_img)
+    end
+    if cnt > 0 then
+      local align_command = "align_image_stack -m -a /tmp/OUT " .. align_img_list
+      dt.print(_("Aligning images..."))
+      if dt.control.execute(align_command) then
+        dt.print(_("Image alignment failed"))
         os.remove(response_file)
-
-        -- import resulting tiff
-        local image = dt.database.import(output_image)
-
-        -- tell the user that everything worked
-        dt.print("enfuse was successful, resulting image was imported")
-        -- normally printing to stdout is bad, but we allow enfuse to show its output, so adding one extra line is ok
-        print("enfuse: done, resulting image '"..output_image.."' was imported with id "..image.id)
+        return nil
+      else
+        -- alignment succeeded, so we'll use the /tmp/OUTxxxx.tif files
+        for _,exp_img in pairs(image_table) do
+          os.remove(exp_img)
+        end
+        -- get a list of the /tmp/OUTxxxx.tif files and put it in the response file
+        a = io.popen("ls /tmp/OUT*")
+        if a then
+          local aligned_file = a:read()
+          while aligned_file do
+            f:write(aligned_file .. "\n")
+            aligned_file = a:read()
+          end
+          a:close()
+          f:close()
+        else
+          dt.print(_("No aligned images found"))
+          os.remove(response_file)
+          return nil
+        end
       end
-    }
-  },
-  nil,-- view_enter
-  nil -- view_leave
-)
+    end
+  else
+    -- add all filenames to the response file
+    for img, exp_img in pairs(image_table) do
+      cnt = cnt + 1
+      f:write(exp_img .. "\n")
+    end
+    f:close()
+  end
 
--- vim: shiftwidth=2 expandtab tabstop=2 cindent syntax=lua
--- kate: hl Lua;
+  if cnt == 0 then
+    os.remove(response_file)
+    dt.print(_("no suitable images selected, nothing to do for enfuse"))
+    return nil
+  else
+    return response_file
+  end
+end
+
+-- ... and tell dt about it all
+
+local function enfuse_hdr(storage, image_table, extra_data)
+  -- remember exposure_mu
+  -- TODO: find a way to save it whenever the value changes
+  local mu = exposure_mu.value
+  dt.preferences.write("enfuse", "exposure_mu", "float", mu)
+
+  -- save the depth value
+  dt.preferences.write("enfuse", "depth", "integer", depth.value / 8)
+
+  local will_align = false
+  if can_align then
+    will_align = hdr_align.value
+  end
+
+  -- create a temp response file
+  local response_file = build_response_file(image_table, will_align)
+
+  local target_dir
+  local hdr_file_name = ""
+  for img, exp_img in pairs(image_table) do
+    target_dir = img.path
+    hdr_file_name = get_basename(exp_img) .. '-' .. hdr_file_name
+  end
+
+  -- append hdr to the generated file name
+  hdr_file_name = hdr_file_name .. "hdr"
+
+  local output_image = target_dir.."/" .. hdr_file_name .. ".tif"
+
+  while checkIfFileExists(output_image) do
+    output_image = filename_increment(output_image)
+    -- limit to 99 more hdr attempts
+    if string.match(get_basename(output_image), "_(d-)$") == "99" then 
+      break 
+    end
+  end
+
+  -- call enfuse on the response file
+  local command = enfuse_executable .. " --depth "..depth.value.." --exposure-mu "..fixSliderFloat(mu)
+                  .." -o \""..output_image.."\" \"@"..response_file.."\""
+  dt.print(_("Launching enfuse..."))
+  if dt.control.execute(command) then
+    dt.print(_("enfuse failed, see terminal output for details"))
+    os.remove(response_file)
+    return
+  end
+
+  -- remove exported images
+  local f = io.open(response_file)
+  fname = f:read()
+  while fname do
+    os.remove(fname)
+    fname = f:read()
+  end
+  f:close()
+  
+  -- remove the response file
+  os.remove(response_file)
+
+  -- import resulting tiff
+  local image = dt.database.import(output_image)
+
+  -- tell the user that everything worked
+  dt.print(_("enfuse was successful, resulting image was imported"))
+  -- normally printing to stdout is bad, but we allow enfuse to show its output, so adding one extra line is ok
+  print("enfuse: done, resulting image '"..output_image.."' was imported with id "..image.id)
+end
+
+local function enfuse_stack(storage, image_table, extra_data)
+  local stack_args = " --exposure-weight=0 --saturation-weight=0 --contrast-weight=1 --hard-mask "
+
+  -- save the depth value
+  dt.preferences.write("enfusestack", "depth", "integer", stack_depth.value / 8)
+
+  local will_align = false
+  if can_align then
+    will_align = stack_align.value
+  end
+
+  -- create a temp response file
+  local response_file = build_response_file(image_table, can_align)
+
+  local target_dir
+  local stack_file_name = ""
+  local first = true
+  local file_name = ""
+  for img, exp_img in pairs(image_table) do
+    target_dir = img.path
+    filename = get_basename(exp_img)
+    if first then
+      stack_file_name = filename
+      first = false
+    end
+  end
+
+  -- append hdr to the generated file name
+  stack_file_name = stack_file_name .. "-" .. filename .. "-stack"
+
+  -- call enfuse on the response file
+  -- TODO: find something nicer
+  -- local ugly_decimal_point_hack = string.gsub(string.format("%.04f", mu), ",", ".")
+  -- TODO: make filename unique - done
+  local output_image = target_dir.."/" .. stack_file_name .. ".tif"
+
+  while checkIfFileExists(output_image) do
+    output_image = filename_increment(output_image)
+    -- limit to 99 more hdr attempts
+    if string.match(get_basename(output_image), "_(d-)$") == "99" then 
+      break 
+    end
+  end
+
+  local command = enfuse_executable .. " --depth "..depth.value
+                  ..stack_args.." --gray-projector="..gray_projector.value
+                  .." --contrast-window-size="..contrast_window.value
+                  .." --contrast-edge-scale="..fixSliderFloat(contrast_edge.value)
+                  .." -o \""..output_image.."\" \"@"..response_file.."\""
+  dt.print(_("Launching enfuse..."))
+  if dt.control.execute(command) then
+    dt.print(_("enfuse failed, see terminal output for details"))
+    os.remove(response_file)
+    return
+  end
+
+  -- remove exported images
+  local f = io.open(response_file)
+  fname = f:read()
+  while fname do
+    os.remove(fname)
+    fname = f:read()
+  end
+  f:close()
+  
+  -- remove the response file
+  os.remove(response_file)
+
+  -- import resulting tiff
+  local image = dt.database.import(output_image)
+
+  -- tell the user that everything worked
+  dt.print(_("enfuse was successful, resulting image was imported"))
+  -- normally printing to stdout is bad, but we allow enfuse to show its output, so adding one extra line is ok
+  print("enfuse: done, resulting image '"..output_image.."' was imported with id "..image.id)
+end
+
+if enfuse_installed then
+  dt.register_storage("module_enfusehdr", _("Enfuse HDR"), show_status, enfuse_hdr, nil, nil, hdr_widget)
+  dt.register_storage("module_enfusestack", _("Enfuse Focus Stack"), show_status, enfuse_stack, nil, nil, stack_widget)
+end

--- a/official/enfuse.lua
+++ b/official/enfuse.lua
@@ -159,7 +159,7 @@ end
 -- set up some hdr widgets, initialized from config
 local exposure_mu = dt.new_widget("slider")
 {
-  label = "exposure mu",
+  label = _("exposure mu"),
   tooltip = _("center also known as MEAN of Gaussian weighting function (0 <= MEAN <= 1); default: 0.5"),
   hard_min = 0,
   hard_max = 1,
@@ -168,7 +168,7 @@ local exposure_mu = dt.new_widget("slider")
 
 local depth = dt.new_widget("combobox")
 {
-  label = "depth",
+  label = _("depth"),
   tooltip = _("output image bits per channel"),
   value = dt.preferences.read("enfuse", "depth", "integer"), "8", "16", "32"
 }
@@ -203,28 +203,28 @@ end
 
 local stack_depth = dt.new_widget("combobox")
 {
-  label = "depth",
+  label =  _("depth"),
   tooltip = _("output image bits per channel"),
   value = dt.preferences.read("enfusestack", "depth", "integer") or 2, "8", "16", "32"
 }
 
 local gray_projector = dt.new_widget("combobox")
 {
-  label = "gray projector",
+  label =  _("gray projector"),
   tooltip = _("type of grayscale conversion, default = average"),
   value = 1, "average", "l-star"
 }
 
 local contrast_window = dt.new_widget("combobox")
 {
-  label = "contrast window size",
+  label =  _("contrast window size"),
   tooltip = _("size of box used for contrast detection, >= 3, default 5"),
   value = 3, "3", "4", "5", "6", "7", "8", "9"
 }
 
 local contrast_edge = dt.new_widget("slider")
 {
-  label = "contrast edge scale",
+  label =  _("contrast edge scale"),
   tooltip = _("laplacian edge detection, 0 disables, >0 enables, .3 is a good starting value"),
   hard_min = 0,
   hard_max = 1,
@@ -410,6 +410,23 @@ local function build_response_file(image_table, will_align)
   end
 end
 
+-- clean up after we've run or crashed
+local function cleanup(res_file)
+  -- remove exported images
+  local f = io.open(res_file)
+  fname = f:read()
+  while fname do
+    os.remove(fname)
+    fname = f:read()
+  end
+  f:close()
+  
+  -- remove the response file
+  os.remove(res_file)
+end
+
+
+
 -- ... and tell dt about it all
 
 local function enfuse_hdr(storage, image_table, extra_data)
@@ -454,21 +471,11 @@ local function enfuse_hdr(storage, image_table, extra_data)
   dt.print(_("Launching enfuse..."))
   if dt.control.execute(command) then
     dt.print(_("enfuse failed, see terminal output for details"))
-    os.remove(response_file)
+    cleanup(response_file)
     return
   end
 
-  -- remove exported images
-  local f = io.open(response_file)
-  fname = f:read()
-  while fname do
-    os.remove(fname)
-    fname = f:read()
-  end
-  f:close()
-  
-  -- remove the response file
-  os.remove(response_file)
+  cleanup(response_file)
 
   -- import resulting tiff
   local image = dt.database.import(output_image)
@@ -528,21 +535,11 @@ local function enfuse_stack(storage, image_table, extra_data)
   dt.print(_("Launching enfuse..."))
   if dt.control.execute(command) then
     dt.print(_("enfuse failed, see terminal output for details"))
-    os.remove(response_file)
+    cleanup(response_file)
     return
   end
 
-  -- remove exported images
-  local f = io.open(response_file)
-  fname = f:read()
-  while fname do
-    os.remove(fname)
-    fname = f:read()
-  end
-  f:close()
-  
-  -- remove the response file
-  os.remove(response_file)
+  cleanup(response_file)
 
   -- import resulting tiff
   local image = dt.database.import(output_image)

--- a/official/enfuse.lua
+++ b/official/enfuse.lua
@@ -69,9 +69,6 @@
       generate an hdr on a fast machine.  Focus stacking takes longer.  These numbers assume using 
       the single thread version of enfuse.  enfuse-mp gives much better results.
 
-    TODO
-    * remember the exposure_mu value in config when the slider is moved
-
     CHANGES
     * 20160828 - Bill Ferguson 
       * Since enfuse can't process raw images, converted it to a storage so that raws can be converted
@@ -81,8 +78,10 @@
         with a decimal point instead of a comma in some languages
       * Fixed TODO - make the output filename unique so you can use it more than once per filmroll
       * Fixed TODO - export images that are not ldr and remove them afterwards
-      * TODO - save exposure-mu value when changed.  The value gets saved when the storage is executed.  It does not 
-        get saved every time the slider is moved.  
+      * Removed TODO - save exposure-mu value when changed.  The value gets saved when the storage is executed.  It does not 
+        get saved every time the slider is moved.  The slider api does not support a changed_callback.  The value is saved
+        when Enfuse HDR runs.  I'm not sure there is any reason to save the slider value whenever it is changed and Enfuse HDR
+        is not executed.
       * Added German message translations
       * Check for the multiprocessor version of enfuse and use it if installed.  On my system the mp version is 5 - 6 
         times faster (i7-6820HK CPU @ 2.70GHz)
@@ -415,7 +414,6 @@ end
 
 local function enfuse_hdr(storage, image_table, extra_data)
   -- remember exposure_mu
-  -- TODO: find a way to save it whenever the value changes
   local mu = exposure_mu.value
   dt.preferences.write("enfuse", "exposure_mu", "float", mu)
 
@@ -512,9 +510,6 @@ local function enfuse_stack(storage, image_table, extra_data)
   stack_file_name = stack_file_name .. "-" .. filename .. "-stack"
 
   -- call enfuse on the response file
-  -- TODO: find something nicer
-  -- local ugly_decimal_point_hack = string.gsub(string.format("%.04f", mu), ",", ".")
-  -- TODO: make filename unique - done
   local output_image = target_dir.."/" .. stack_file_name .. ".tif"
 
   while checkIfFileExists(output_image) do


### PR DESCRIPTION
Fixed the TODO list in official/enfuse.lua

Summary of  changes:

- Since enfuse can't process raw images, converted it to a storage so that raws can be converted and processed.  Named it Enfuse HDR
-  Added another storage to take advantage of enfuse's ability to process focus stack images and named it  Enfuse Focus Stack
- Fixed TODO - find a less stupid way to make sure the float value of exposure_mu gets turned into a string with a decimal point instead of a comma in some languages
- Fixed TODO - make the output filename unique so you can use it more than once per filmroll
- Fixed TODO - export images that are not ldr and remove them afterwards
- Removed TODO - save exposure-mu value when changed.  The value gets saved when the storage is executed.  It does not get saved every time the slider is moved.  The slider api does not support a changed_callback.  I'm not sure there  is any reason to save the slider value whenever it is changed and Enfuse HDR is not executed.
- Added German message translations
- Check for the multiprocessor version of enfuse and use it if installed.  On my system the mp version is 5 - 6  times faster (i7-6820HK CPU @ 2.70GHz)
- Added an option to align images using align_image_stack, part of the hugin project, if installed.

