### PR TITLE
require official/yield in scripts using dt.control.execute()

### DIFF
--- a/contrib/geoJSON_export.lua
+++ b/contrib/geoJSON_export.lua
@@ -33,6 +33,8 @@ USAGE
 ]]
    
 local dt = require "darktable"
+require "official/yield"
+
 local gettext = dt.gettext
 dt.configuration.check_version(...,{3,0,0})
 	

--- a/contrib/geo_uri.lua
+++ b/contrib/geo_uri.lua
@@ -27,6 +27,8 @@ USAGE
 ]]
 
 local dt = require "darktable"
+require "official/yield"
+
 local gettext = dt.gettext
 dt.configuration.check_version(...,{3,0,0})
 

--- a/contrib/gimp.lua
+++ b/contrib/gimp.lua
@@ -64,6 +64,8 @@
 ]]
 
 local dt = require "darktable"
+require "official/yield"
+
 local gettext = dt.gettext
 
 dt.configuration.check_version(...,{3,0,0})

--- a/contrib/hugin.lua
+++ b/contrib/hugin.lua
@@ -34,6 +34,8 @@ This plugin will add a new storage option and calls hugin after export.
 ]]
 
 local dt = require "darktable"
+require "official/yield"
+
 local gettext = dt.gettext
 
 -- works with darktable API version 2.0.0 and 3.0.0

--- a/contrib/kml_export.lua
+++ b/contrib/kml_export.lua
@@ -37,6 +37,8 @@ USAGE
 ]]
    
 local dt = require "darktable"
+require "official/yield"
+
 local gettext = dt.gettext
 dt.configuration.check_version(...,{3,0,0})
 	

--- a/contrib/slideshowMusic.lua
+++ b/contrib/slideshowMusic.lua
@@ -25,6 +25,8 @@ USAGE
 ]]
    
 local dt = require "darktable"
+require "official/yield"
+
 local gettext = dt.gettext
 dt.configuration.check_version(...,{2,0,2},{3,0,0})
 

--- a/contrib/video_mencoder.lua
+++ b/contrib/video_mencoder.lua
@@ -31,6 +31,8 @@ USAGE
 ]]
 
 local dt = require "darktable"
+require "official/yield"
+
 dt.configuration.check_version(...,{2,0,1})
 
 local function show_status(storage, image, format, filename, number, total, high_quality, extra_data)

--- a/official/enfuse.lua
+++ b/official/enfuse.lua
@@ -33,6 +33,8 @@ TODO
 ]]
 
 local dt = require "darktable"
+require "official/yield"
+
 
 dt.configuration.check_version(...,{3,0,0})
 

--- a/official/generate_image_txt.lua
+++ b/official/generate_image_txt.lua
@@ -36,6 +36,8 @@ USAGE
 
 local dt = require "darktable"
 require "darktable.debug"
+require "official/yield"
+
 dt.configuration.check_version(...,{2,1,0},{3,0,0})
 
 dt.preferences.register("generate_image_txt",

--- a/official/selection_to_pdf.lua
+++ b/official/selection_to_pdf.lua
@@ -34,6 +34,8 @@ Plugin allows you to choose how many thumbnails you need per row
 
 ]]
 local dt = require "darktable"
+require "official/yield"
+
 dt.configuration.check_version(...,{2,0,0},{3,0,0})
 
 dt.preferences.register


### PR DESCRIPTION
If official/yield.lua is not required in the luarc file then scripts using dt.control.execute() silently fail (i.e. message shows "Launching GIMP" and nothing happens).  I've seen this in several mailing lists and the reply is always require official/yield.  I figure that it's better to fix it at the source, and just require it in the scripts that need it.  If it's already been loaded, then lua will use that copy rather than loading it again.  This should alleviate user frustration with the scripts not working as advertised.