### PR TITLE
Selection of untagged images

### DIFF
--- a/contrib/select_untagged.lua
+++ b/contrib/select_untagged.lua
@@ -1,0 +1,65 @@
+--[[
+    This file is part of darktable,
+    copyright (c) 2017 Jannis_V
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    darktable is distributed in the hope that it will be useful,
+     but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+]]
+
+--[[
+Enable selection of untagged images (darktable|* tags are ignored)
+]]
+
+local dt = require "darktable"
+require "official/yield"
+local gettext = dt.gettext
+
+dt.configuration.check_version(...,{3,0,0},{4,0,0},{5,0,0})
+
+-- Tell gettext where to find the .mo file translating messages for a particular domain
+gettext.bindtextdomain("select_untagged",dt.configuration.config_dir.."/lua/locale/")
+
+local function _(msgid)
+  return gettext.dgettext("select_untagged", msgid)
+end
+
+local function stop_job(job)
+  job.valid = false
+end
+
+local function select_untagged_images()
+  job = dt.gui.create_job(_("select untagged images"), true, stop_job)
+
+  local selection = {}
+
+  for key,image in ipairs(dt.collection) do
+    if(job.valid) then
+      job.percent = (key-1)/#dt.collection
+      local tags =  dt.tags.get_tags(image)
+      local hasTags = false
+      for _,tag in ipairs(tags) do
+        if not string.match(tag.name,"darktable|") then
+          hasTags = true
+        end
+      end
+      if hasTags == false then
+        table.insert(selection,image)
+      end
+    else
+      break
+    end
+  end
+
+  job.valid = false
+  dt.gui.selection(selection)
+end
+
+dt.gui.libs.select.register_selection(_("select untagged"),select_untagged_images,_("select all images containing no tags or only tags added by darktable"))

--- a/contrib/select_untagged.lua
+++ b/contrib/select_untagged.lua
@@ -19,7 +19,6 @@ Enable selection of untagged images (darktable|* tags are ignored)
 ]]
 
 local dt = require "darktable"
-require "official/yield"
 local gettext = dt.gettext
 
 dt.configuration.check_version(...,{3,0,0},{4,0,0},{5,0,0})

--- a/locale/de_DE/LC_MESSAGES/select_untagged.po
+++ b/locale/de_DE/LC_MESSAGES/select_untagged.po
@@ -1,0 +1,27 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: 2017-09-14 12:18+0200\n"
+"PO-Revision-Date: 2017-09-14 12:23+0200\n"
+"Last-Translator: Jannis_V\n"
+"Language-Team: \n"
+"Language: de_DE\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.7.1\n"
+"X-Poedit-Basepath: ../../../contrib\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Poedit-SearchPath-0: select_untagged.lua\n"
+
+#: select_untagged.lua:38
+msgid "select untagged images"
+msgstr "Auswahl von Bildern ohne Tags"
+
+#: select_untagged.lua:64
+msgid "select untagged"
+msgstr "Ohne Tags"
+
+#: select_untagged.lua:64
+msgid "select all images containing no tags or only tags added by darktable"
+msgstr "Wähle alle Bilder der aktuellen Sammlung aus, die keine Tags oder nur automatisch durch darktable erzeugte Tags enthalten"

--- a/locale/fr_FR/LC_MESSAGES/select_untagged.po
+++ b/locale/fr_FR/LC_MESSAGES/select_untagged.po
@@ -1,0 +1,27 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: 2017-09-14 15:42+0200\n"
+"PO-Revision-Date: 2017-09-14 15:52+0200\n"
+"Last-Translator: Jannis_V\n"
+"Language-Team: \n"
+"Language: fr_FR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.7.1\n"
+"X-Poedit-Basepath: ../../../contrib\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Poedit-SearchPath-0: select_untagged.lua\n"
+
+#: select_untagged.lua:38
+msgid "select untagged images"
+msgstr "sélection des images sans mots-clés"
+
+#: select_untagged.lua:64
+msgid "select untagged"
+msgstr "sans mots-clés"
+
+#: select_untagged.lua:64
+msgid "select all images containing no tags or only tags added by darktable"
+msgstr "sélection des images sans mots-clés ou seulement avec les mots-clés ajoutés par darktable"


### PR DESCRIPTION
When tagging my collection, I was looking for a way to find untagged images in darktable. All I found were older threads and a [feature request from five years ago](https://redmine.darktable.org/issues/8792).

So I wrote a lua script which checks the collection for untagged images and adds them to the selection. Images having no tags at all or only tags added by darktable (e.g. darktable|format|cr2) are considered untagged.

Maybe this is interesting for some other users, or did I miss an official way to show untagged images?