### PR TITLE
Fix macOS returned path  and add wine awareness to check_if_bin_exists()

### DIFF
--- a/lib/dtutils/file.lua
+++ b/lib/dtutils/file.lua
@@ -67,7 +67,10 @@ function dtutils_file.check_if_bin_exists(bin)
   if string.len(path) > 0 then
     if dtutils_file.check_if_file_exists(path) then
       path = "\"" .. path .. "\""
-      if (string.match(path, ".exe$") or string.match(path, ".EXE%")) and dt.configuration.running_os ~= "windows" then
+      if (string.match(path, ".exe$") or string.match(path, ".EXE%")) and 
+        dt.configuration.running_os ~= "windows" or 
+        result = "wine " .. path
+      elseif dt.configuration.running_os == "macos" then
         result = "open -a -W " .. path
       else
         result = path

--- a/lib/dtutils/file.lua
+++ b/lib/dtutils/file.lua
@@ -67,12 +67,7 @@ function dtutils_file.check_if_bin_exists(bin)
   if string.len(path) > 0 then
     if dtutils_file.check_if_file_exists(path) then
       path = "\"" .. path .. "\""
-      if (string.match(path, ".exe$") or string.match(path, ".EXE%")) and 
-        (dt.configuration.running_os == "linux" or 
-         dt.configuration.running_os == "unix" or
-         dt.configuration.running_os == "macos") then
-        result = "wine " .. path
-      elseif dt.configuration.running_os == "macos" then
+      if (string.match(path, ".exe$") or string.match(path, ".EXE%")) and dt.configuration.running_os ~= "windows" then
         result = "open -a -W " .. path
       else
         result = path

--- a/lib/dtutils/file.lua
+++ b/lib/dtutils/file.lua
@@ -523,7 +523,6 @@ function dtutils_file.executable_path_widget(executables)
       value = path,
       is_directory = false,
       changed_callback = function(self)
-        dt.print_log("checking that " .. self.value .. " exists")
         if dtutils_file.check_if_bin_exists(self.value) then
           dtutils_file.set_executable_path_preference(executable, self.value)
         end

--- a/lib/dtutils/file.lua
+++ b/lib/dtutils/file.lua
@@ -67,8 +67,7 @@ function dtutils_file.check_if_bin_exists(bin)
   if string.len(path) > 0 then
     if dtutils_file.check_if_file_exists(path) then
       path = "\"" .. path .. "\""
-      if (string.match(path, ".exe$") or string.match(path, ".EXE%")) and 
-        dt.configuration.running_os ~= "windows" or 
+      if (string.match(path, ".exe\"$") or string.match(path, ".EXE\"$")) and dt.configuration.running_os ~= "windows" then
         result = "wine " .. path
       elseif dt.configuration.running_os == "macos" then
         result = "open -a -W " .. path


### PR DESCRIPTION
@wejot tested macOS changes to check_if_bin_exists and we came up with prepending "open -a -W " to the path, which works with path selection gui.

I also added a check to see if the path ended in .exe or .EXE and the operating system wasn't windows.  If that was the case then I prepended "wine " to the path so that we could call windows executables running under wine.

I also wrapped the string passed to check_if_file_exists() in quotes to get around spaces in the file and path names, discovered while I was testing the wine awareness.