### PR TITLE
Replace placeholder for dt.print_log with dt.print_log

### DIFF
--- a/lib/dtutils/log.lua
+++ b/lib/dtutils/log.lua
@@ -242,6 +242,7 @@ function dtutils_log.log_level(...)
     for _,v in ipairs(levels) do
       if dtutils_log[v].enabled == true then
         log_level = dtutils_log[v]
+        break
       end
     end
   end


### PR DESCRIPTION
lib/dtutils/log.lua was written with the knowledge that the darktable.print_log function was being developed, so a placeholder was inserted in the code.  Now that the function exists the placeholder is being replaced with the function.