### PR TITLE
hugin fails on images with spaces in the filenames

### DIFF
--- a/contrib/hugin.lua
+++ b/contrib/hugin.lua
@@ -37,17 +37,19 @@ This plugin will add a new storage option and calls hugin after export.
 
 local dt = require "darktable"
 local df = require "lib/dtutils.file"
+local log = require "lib/dtutils.log"
 require "official/yield"
 local gettext = dt.gettext
 
 local namespace = 'module_hugin'
 local user_pref_str = 'prefer_gui'
 local user_prefer_gui = dt.preferences.read(namespace, user_pref_str, "bool")
+log.msg(log.info, "user_prefer_gui set to ", user_prefer_gui)
 local hugin_widget = nil
 local exec_widget = nil
 local executable_table = {"hugin", "hugin_executor", "pto_gen"}
 
--- works with darktable API version from 2.0.0 to 5.0.0
+-- works with darktable API version from 5.0.0 on
 dt.configuration.check_version(...,{5,0,0})
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
@@ -73,15 +75,28 @@ local function create_panorama(storage, image_table, extra_data) --finalize
 -- We need pto_gen to create pto file for hugin_executor
 -- http://hugin.sourceforge.net/docs/manual/Pto_gen.html
 
+  -- save the current log level and set log level to
+  --   log.error for normal operations
+  --   log.info for more insight about what is happening
+  --   log.debug for even more information
+
+  local saved_log_level = log.log_level()
+  log.log_level(log.error)
+
   local hugin = df.check_if_bin_exists("hugin")
+  log.msg(log.info, "hugin set to ", hugin)
   local hugin_executor = df.check_if_bin_exists("hugin_executor")
+  log.msg(log.info, "hugin_executor set to ", hugin_executor)
   local pto_gen = df.check_if_bin_exists("pto_gen")
+  log.msg(log.info, "pto_gen set to ", pto_gen)
 
   local gui_available = false
   if hugin then
     gui_available = true
   else
     dt.print(_("hugin is not found, did you set the path?"))
+    log.msg(log.error, "hugin executable not found.  Check if the executable is installed.")
+    log.msg(log.error, "If the executable is installed, check that the path is set correctly.")
     return
   end
 
@@ -91,21 +106,24 @@ local function create_panorama(storage, image_table, extra_data) --finalize
   end
 
   -- list of exported images
-  local img_list
+  local img_list = ""
   local img_set = {}
 
   -- reset and create image list
-  img_list = ""
   for k,v in pairs(image_table) do
-    img_list = img_list..v..' '
+    log.msg(log.debug, "k is ", k, " and v is ", v)
+    img_list = img_list .. "'" .. v .. "'" .. ' '  -- surround the filename with single quotes to handle spaces
     table.insert(img_set, k)
   end
+
+  log.msg(log.info, "img_list is ", img_list)
 
   -- use first file as basename for output file
   table.sort(img_set, function(a,b) return a.filename<b.filename end);
   local first_file
   for _, k in ipairs(img_set) do
-    first_file = k break
+    first_file = k 
+    break
   end
 
   if first_file == nil then
@@ -114,37 +132,50 @@ local function create_panorama(storage, image_table, extra_data) --finalize
   end
 
   local pto_path = dt.configuration.tmp_dir..'/project.pto'
+  log.msg(log.info, "pto_path is ", pto_path)
   local filepath = df.split_filepath(first_file.filename)
+  log.msg(log.info, "filepath is ", filepath)
   local tmp_filename = filepath['basename'].."_pano.tif"
+  log.msg(log.info, "tmp_filename is ", tmp_filename)
 -- some versions of hugin_executor don't seem to output the result
 -- to the --prefix location, so assume we are working in the tmp
 -- directory and then move the file to the original file location afterwards
   local src_path = dt.configuration.tmp_dir.."/"..tmp_filename
+  log.msg(log.info, "src_path is ", src_path)
   local dst_path = first_file.path..'/'..tmp_filename
+  log.msg(log.info, "dst_path is ", dst_path)
 
   if df.check_if_file_exists(dst_path) then
     dst_path = df.create_unique_filename(dst_path)
+    log.msg(log.info, "dst_path updated to ", dts_path)
   end
 
   dt.print(_("will try to stitch now"))
   local huginStartCommand = nil
   if (cmd_line_available and not user_prefer_gui) then
+    log.msg(log.info, "using the command line tools to create panorama")
     huginStartCommand = pto_gen.." "..img_list.." -o "..pto_path
     dt.print(_("creating pto file"))
+    log.msg(log.info, "pto creation command is ", huginStartCommand)
     dt.control.execute(huginStartCommand)
 
-    dt.print(_("running assistent"))
+    dt.print(_("running assistant"))
     huginStartCommand = hugin_executor.." --assistant "..pto_path
     dt.control.execute(huginStartCommand)
 
-    huginStartCommand = hugin_executor..' --stitching --prefix='..src_path..' '..pto_path
+    huginStartCommand = hugin_executor..' --stitching --prefix=' .. "'" .. src_path .. "'" .. ' ' .. pto_path
+    log.msg(log.info, "command line huginStartCommand is ", huginStartCommand)
   elseif gui_available then
     if (user_prefer_gui) then
       dt.print(_("launching hugin"))
     else
       dt.print(_("unable to find command line tools, launching hugin"))
     end
+    -- the gui produces a differnt output filename than the command line
+    src_path = dt.configuration.tmp_dir .. "/" .. df.get_basename(img_set[1].filename) .. " - " .. df.get_basename(img_set[#img_set].filename) .. ".tif"
+    log.msg(log.info, "set src_path to ", src_path)
     huginStartCommand = hugin..' '..img_list
+    log.msg(log.info, "gui huginStartCommand is ", huginStartCommand)
   else
     dt.print(_("hugin isn't available."))
   end
@@ -152,13 +183,16 @@ local function create_panorama(storage, image_table, extra_data) --finalize
   if not (huginStartCommand==nil) then
     if not dt.control.execute(huginStartCommand) then
       dt.print(_("hugin failed ..."))
+      log.msg(log.error, huginStartCommand, " failed")
     else
       if df.check_if_file_exists(src_path) then
+        log.msg(log.debug, "found ", src_path, " importing to ", dst_path)
         df.file_move(src_path, dst_path)
         dt.print(_("importing file "..dst_path))
         dt.database.import(dst_path)
       end
     end
+    log.log_level(saved_log_level)
   end
 
   -- cleanup the temp files
@@ -185,6 +219,7 @@ hugin_widget = dt.new_widget("box") {
 }
 
 dt.register_storage(namespace, _("hugin panorama"), show_status, create_panorama, nil, nil, hugin_widget)
+
 
 --
 -- vim: shiftwidth=2 expandtab tabstop=2 cindent syntax=lua


### PR DESCRIPTION
single quoted filename arguments to the hugin commands for the supplied image files.  Single quoted any filenames derived from the supplied image files in case they contained spaces.  Added logging at various levels so that the next time I have to work on this I can figure it out quicker.  Normal logging level is log.error which only prints error information.  Changing log level to log.info provides much more insight about what is occurring.  Fixed gui not returning generated file to film strip.