### PR TITLE
MacOS Command Fixes

### DIFF
--- a/contrib/gimp.lua
+++ b/contrib/gimp.lua
@@ -119,6 +119,10 @@ local function gimp_edit(storage, image_table, extra_data) --finalize
     return
   end
 
+  if dt.configuration.running_os == "macos" then
+    gimp_executable = "open -W -a " .. gimp_executable
+  end
+
   -- list of exported images
   local img_list
 

--- a/lib/dtutils/file.lua
+++ b/lib/dtutils/file.lua
@@ -68,8 +68,6 @@ function dtutils_file.check_if_bin_exists(bin)
     if dtutils_file.check_if_file_exists(path) then
       if (string.match(path, ".exe$") or string.match(path, ".EXE$")) and dt.configuration.running_os ~= "windows" then
        result = "wine " .. "\"" .. path .. "\""      
-      elseif dt.configuration.running_os == "macos" then
-        result = "open -W -a " .. "\"" .. path .. "\""
       else
         result = "\"" .. path .. "\""
       end


### PR DESCRIPTION
Adding "open -W -a" appears to only be required on MacOS when opening a GUI.  Command line programs don't run when prefixed with this.  The "open -W -a" was removed from check_if_bin_exists().  It was added to the GIMP executable command line in gimp.lua since it launches a GUI.