### PR TITLE
'LabelsToTags' is standalone.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ gpx_export|No|LMW|Export a GPX track file from selected images GPS data
 hugin|No|LMW|Combine selected images into a panorama and return the result
 image_stack|No|LMW|Combine a stack of images to remove noise or transient objects
 kml_export|No|L|Export photos with a KML file for usage in Google Earth
-LabelsToTags|?|LMW|Apply tags based on color labels and ratings
+LabelsToTags|Yes|LMW|Apply tags based on color labels and ratings
 passport_guide|Yes|LMW|Add passport cropping guide to darkroom crop tool
 pdf_slideshow|No|LM|Export images to a PDF slideshow
 quicktag|Yes|LMW|Create shortcuts for quickly applying tags

--- a/contrib/LabelsToTags.lua
+++ b/contrib/LabelsToTags.lua
@@ -12,6 +12,9 @@
    * Add the following line in the file $CONFIGDIR/luarc:
    require "LabelsToTags"
 
+   ADDITIONAL SOFTWARE NEEDED FOR THIS SCRIPT
+   None.
+
    USAGE
    In your 'luarc' file or elsewhere, use the function
    'register_tag_mapping', defined in this module, to specify


### PR DESCRIPTION
The table of scripts in `README.md` has a question mark in the "Standalone" column for my script, `LabelsToTags`. This change substitutes "Yes" and adds an explicit clarification in the script header.