### PR TITLE
enfuse: convert raws to tiff automatically

### DIFF
--- a/official/enfuse.lua
+++ b/official/enfuse.lua
@@ -121,7 +121,7 @@ dt.register_lib(
     dt.new_widget("button")
     {
       label = enfuse_installed and "run enfuse" or "enfuse not installed",
-      clicked_callback = function (_)
+      clicked_callback = function ()
         -- remember exposure_mu
         -- TODO: find a way to save it whenever the value changes
         local mu = exposure_mu.value
@@ -135,7 +135,7 @@ dt.register_lib(
         local response_file = os.tmpname()
         local f = io.open(response_file, "w")
         if not f then
-          dt.print("error writing to `"..response_file.."'")
+          dt.print(string.format(_("Error writing to `%s`"), response_file))
           os.remove(response_file)
           return
         end
@@ -144,7 +144,7 @@ dt.register_lib(
         local cnt = 0
         local n_skipped = 0
         local target_dir
-        for _, i in ipairs(dt.gui.action_images) do
+        for i_, i in ipairs(dt.gui.action_images) do
           -- only use ldr files as enfuse can't open raws. alternatively we could export raws that we encounter
           if i.is_ldr then
             cnt = cnt + 1
@@ -152,28 +152,27 @@ dt.register_lib(
             target_dir = i.path
           elseif i.is_raw and darktable_cli_installed then
             local tmp_exported = os.tmpname()..".tif"
+            dt.print(string.format(_("Converting raw file '%s' to tiff..."), i.filename)) 
             os.execute("darktable-cli \""..i.path.."/"..i.filename.."\" \""..tmp_exported.."\"")
-            dt.print("Raw file "..i.filename.." automatically converted to tiff")
 
             cnt = cnt + 1
             f:write(tmp_exported.."\n")
             target_dir = i.path
           else
-            dt.print("skipping "..i.filename)
+            dt.print(string.format(_("Skipping %s..."), i.filename))
             n_skipped = n_skipped + 1
           end
         end
         f:close()
         -- bail out if there is nothing to do
         if cnt == 0 then
-          dt.print("no suitable images selected, nothing to do for enfuse")
+          dt.print(_("No suitable images selected, nothing to do for enfuse"))
           os.remove(response_file)
           return
         end
-        if n_skipped == 1 then
-          dt.print(n_skipped.." image skipped")
-        elseif n_skipped > 1 then
-          dt.print(n_skipped.." images skipped")
+
+        if n_skipped > 0 then
+          dt.print(string.format(_("%d image(s) skipped"), n_skipped))
         end
 
         -- call enfuse on the response file
@@ -188,7 +187,7 @@ dt.register_lib(
         local command = "enfuse --depth "..depth.value..exposure_option..ugly_decimal_point_hack
                         .." -o \""..output_image.."\" \"@"..response_file.."\""
         if dt.control.execute( command) > 0 then
-          dt.print("enfuse failed, see terminal output for details")
+          dt.print(_("Enfuse failed, see terminal output for details"))
           os.remove(response_file)
           return
         end
@@ -200,9 +199,9 @@ dt.register_lib(
         local image = dt.database.import(output_image)
 
         -- tell the user that everything worked
-        dt.print("enfuse was successful, resulting image was imported")
+        dt.print(_("enfuse was successful, resulting image has been imported"))
         -- normally printing to stdout is bad, but we allow enfuse to show its output, so adding one extra line is ok
-        print("enfuse: done, resulting image '"..output_image.."' was imported with id "..image.id)
+        print(string.format(_("enfuse: done, resulting image '%s' has been imported with id %d"), output_image, image.id))
       end
     }
   },

--- a/official/enfuse.lua
+++ b/official/enfuse.lua
@@ -49,6 +49,7 @@ end
 -- add a new lib
 -- is enfuse installed?
 local enfuse_installed = df.check_if_bin_exists("enfuse")
+local darktable_cli_installed = df.check_if_bin_exists("darktable-cli")
 
 -- check the version so that we can use the correct arguments
 
@@ -148,6 +149,14 @@ dt.register_lib(
           if i.is_ldr then
             cnt = cnt + 1
             f:write(i.path.."/"..i.filename.."\n")
+            target_dir = i.path
+          elseif i.is_raw and darktable_cli_installed then
+            local tmp_exported = os.tmpname()..".tif"
+            os.execute("darktable-cli \""..i.path.."/"..i.filename.."\" \""..tmp_exported.."\"")
+            dt.print("Raw file "..i.filename.." automatically converted to tiff")
+
+            cnt = cnt + 1
+            f:write(tmp_exported.."\n")
             target_dir = i.path
           else
             dt.print("skipping "..i.filename)


### PR DESCRIPTION
it uses darktable-cli (if installed) to convert to a temporary file the
raw files that enfuse is not able to process.