### PR TITLE
check_min_api_version

### DIFF
--- a/contrib/LabelsToTags.lua
+++ b/contrib/LabelsToTags.lua
@@ -48,7 +48,12 @@
 ]]
 
 local darktable = require("darktable")
-darktable.configuration.check_version(...,{3,0,0},{4,0,0},{5,0,0})
+local du = require "lib/dtutils"
+
+if not du.check_min_api_version("3.0.0") then
+  darktable.print("ERROR:LabelsToTags failed to load.  Lua API version 3.0.0 or later required.")
+  return
+end
 
 -- Lua 5.3 no longer has "unpack" but "table.unpack"
 unpack = unpack or table.unpack

--- a/contrib/LabelsToTags.lua
+++ b/contrib/LabelsToTags.lua
@@ -50,10 +50,7 @@
 local darktable = require("darktable")
 local du = require "lib/dtutils"
 
-if not du.check_min_api_version("3.0.0") then
-  darktable.print("ERROR:LabelsToTags failed to load.  Lua API version 3.0.0 or later required.")
-  return
-end
+du.check_min_api_version("3.0.0", "LabelsToTags") 
 
 -- Lua 5.3 no longer has "unpack" but "table.unpack"
 unpack = unpack or table.unpack

--- a/contrib/OpenInExplorer.lua
+++ b/contrib/OpenInExplorer.lua
@@ -34,7 +34,14 @@ A file explorer window will be opened for each selected file at the file's locat
 ]]
 
 local dt = require "darktable"
+local du = require "lib/dtutils"
 local dsys = require "lib/dtutils.system"
+
+--Check API version
+if not du.check_min_api_version("5.0.0") then
+  dt.print("ERROR:OpenInExplorer failed to load.  Lua API version 5.0.0 or greater required.")
+  return
+end
 
 --Detect OS and modify accordingly--	
 local proper_install = false

--- a/contrib/OpenInExplorer.lua
+++ b/contrib/OpenInExplorer.lua
@@ -38,10 +38,7 @@ local du = require "lib/dtutils"
 local dsys = require "lib/dtutils.system"
 
 --Check API version
-if not du.check_min_api_version("5.0.0") then
-  dt.print("ERROR:OpenInExplorer failed to load.  Lua API version 5.0.0 or greater required.")
-  return
-end
+du.check_min_api_version("5.0.0", "OpenInExplorer") 
 
 --Detect OS and modify accordingly--	
 local proper_install = false

--- a/contrib/autostyle.lua
+++ b/contrib/autostyle.lua
@@ -37,13 +37,17 @@ GPLv2
 ]]
 
 local darktable = require "darktable"
+local du = require "lib/dtutils"
 local filelib = require "lib/dtutils.file"
 
 -- Forward declare the functions
 local autostyle_apply_one_image,autostyle_apply_one_image_event,autostyle_apply,exiftool_attribute,capture
 
 -- Tested it with darktable 1.6.1 and darktable git from 2014-01-25
-darktable.configuration.check_version(...,{2,0,2},{2,1,0},{3,0,0},{4,0,0},{5,0,0})
+if not du.check_min_api_version("2.0.2") then
+  darktable.print("ERROR:autostyle failed to load.  Lua API version 2.0.2 or later required.")
+  return
+end
 
 -- Receive the event triggered
 function autostyle_apply_one_image_event(event,image)

--- a/contrib/autostyle.lua
+++ b/contrib/autostyle.lua
@@ -44,10 +44,7 @@ local filelib = require "lib/dtutils.file"
 local autostyle_apply_one_image,autostyle_apply_one_image_event,autostyle_apply,exiftool_attribute,capture
 
 -- Tested it with darktable 1.6.1 and darktable git from 2014-01-25
-if not du.check_min_api_version("2.0.2") then
-  darktable.print("ERROR:autostyle failed to load.  Lua API version 2.0.2 or later required.")
-  return
-end
+du.check_min_api_version("2.0.2", "autostyle") 
 
 -- Receive the event triggered
 function autostyle_apply_one_image_event(event,image)

--- a/contrib/clear_GPS.lua
+++ b/contrib/clear_GPS.lua
@@ -43,10 +43,7 @@ local gettext = dt.gettext
 -- not a number
 local NaN = 0/0
 
-if not du.check_min_api_version("3.0.0") then
-  dt.print("ERROR:clear_GPS failed to load.  Lua API version 3.0.0 or later required.")
-  return
-end
+du.check_min_api_version("3.0.0", "clear_GPS") 
 
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain

--- a/contrib/clear_GPS.lua
+++ b/contrib/clear_GPS.lua
@@ -37,12 +37,16 @@
 ]]
 
 local dt = require "darktable"
+local du = require "lib/dtutils"
 local gettext = dt.gettext
 
 -- not a number
 local NaN = 0/0
 
-dt.configuration.check_version(...,{3,0,0},{4,0,0},{5,0,0})
+if not du.check_min_api_version("3.0.0") then
+  dt.print("ERROR:clear_GPS failed to load.  Lua API version 3.0.0 or later required.")
+  return
+end
 
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain

--- a/contrib/copy_attach_detach_tags.lua
+++ b/contrib/copy_attach_detach_tags.lua
@@ -37,10 +37,15 @@ USAGE
 ]]
 
 local dt = require "darktable"
+local du = require "lib/dtutils"
 local debug = require "darktable.debug"
 
 local gettext = dt.gettext
-dt.configuration.check_version(...,{3,0,0},{4,0,0},{5,0,0})
+
+if not du.check_min_api_version("3.0.0") then
+  dt.print("ERROR:copy_attach_detach_tags failed to load.  Lua API version 3.0.0 or later required.")
+  return
+end
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("copy_attach_detach_tags",dt.configuration.config_dir.."/lua/locale/")

--- a/contrib/copy_attach_detach_tags.lua
+++ b/contrib/copy_attach_detach_tags.lua
@@ -42,10 +42,7 @@ local debug = require "darktable.debug"
 
 local gettext = dt.gettext
 
-if not du.check_min_api_version("3.0.0") then
-  dt.print("ERROR:copy_attach_detach_tags failed to load.  Lua API version 3.0.0 or later required.")
-  return
-end
+du.check_min_api_version("3.0.0", "copy_attach_detach_tags") 
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("copy_attach_detach_tags",dt.configuration.config_dir.."/lua/locale/")

--- a/contrib/cr2hdr.lua
+++ b/contrib/cr2hdr.lua
@@ -33,9 +33,13 @@ USAGE
 ]]
 
 local darktable = require "darktable"
+local du = require "lib/dtutils"
 
 -- Tested with darktable 2.0.1
-darktable.configuration.check_version(...,{2,0,0},{3,0,0},{4,0,0},{5,0,0})
+if not du.check_min_api_version("2.0.0") then
+  darktable.print("ERROR:cr2hdr failed to load.  Lua API version 2.0.0 or later required.")
+  return
+end
 
 local queue = {}
 local processed_files = {}

--- a/contrib/cr2hdr.lua
+++ b/contrib/cr2hdr.lua
@@ -36,10 +36,7 @@ local darktable = require "darktable"
 local du = require "lib/dtutils"
 
 -- Tested with darktable 2.0.1
-if not du.check_min_api_version("2.0.0") then
-  darktable.print("ERROR:cr2hdr failed to load.  Lua API version 2.0.0 or later required.")
-  return
-end
+du.check_min_api_version("2.0.0", "cr2hdr")
 
 local queue = {}
 local processed_files = {}

--- a/contrib/enfuseAdvanced.lua
+++ b/contrib/enfuseAdvanced.lua
@@ -67,10 +67,7 @@ local gettext = dt.gettext
 local preferences_version = 1 --When releasing an update increment this number by one if changes have been made to the preferences structure that would require a re-initialization
 
 -- works with LUA API version 5.0.0
-if not du.check_min_api_version("5.0.0") then
-  dt.print("ERROR:enfuseAdvanced failed to load.  Lua API version 5.0.0 or later required.")
-  return
-end
+du.check_min_api_version("5.0.0", "enfuseAdvanced") 
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("enfuseAdvanced",dt.configuration.config_dir.."/lua/")

--- a/contrib/enfuseAdvanced.lua
+++ b/contrib/enfuseAdvanced.lua
@@ -60,13 +60,17 @@ Pops up multiple CMD windows on windows machienes
 ]]
 
 local dt = require "darktable"
+local du = require "lib/dtutils"
 local df = require "lib/dtutils.file"
 local dsys = require "lib/dtutils.system"
 local gettext = dt.gettext
 local preferences_version = 1 --When releasing an update increment this number by one if changes have been made to the preferences structure that would require a re-initialization
 
 -- works with LUA API version 5.0.0
-dt.configuration.check_version(...,{5,0,0})
+if not du.check_min_api_version("5.0.0") then
+  dt.print("ERROR:enfuseAdvanced failed to load.  Lua API version 5.0.0 or later required.")
+  return
+end
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("enfuseAdvanced",dt.configuration.config_dir.."/lua/")

--- a/contrib/fujifilm_ratings.lua
+++ b/contrib/fujifilm_ratings.lua
@@ -28,10 +28,7 @@ local du = require "lib/dtutils"
 local df = require "lib/dtutils.file"
 local gettext = dt.gettext
 
-if not du.check_min_api_version("4.0.0") then
-  dt.print("ERROR:fujifilm_ratings failed to load.  Lua API version 4.0.0 or later required.")
-  return
-end
+du.check_min_api_version("4.0.0", "fujifilm_ratings")
 
 gettext.bindtextdomain("fujifilm_ratings", dt.configuration.config_dir.."/lua/locale/")
 

--- a/contrib/fujifilm_ratings.lua
+++ b/contrib/fujifilm_ratings.lua
@@ -24,10 +24,14 @@ Dependencies:
 --]]
 
 local dt = require "darktable"
+local du = require "lib/dtutils"
 local df = require "lib/dtutils.file"
 local gettext = dt.gettext
 
-dt.configuration.check_version(...,{4,0,0},{5,0,0})
+if not du.check_min_api_version("4.0.0") then
+  dt.print("ERROR:fujifilm_ratings failed to load.  Lua API version 4.0.0 or later required.")
+  return
+end
 
 gettext.bindtextdomain("fujifilm_ratings", dt.configuration.config_dir.."/lua/locale/")
 

--- a/contrib/geoJSON_export.lua
+++ b/contrib/geoJSON_export.lua
@@ -38,10 +38,7 @@ local df = require "lib/dtutils.file"
 require "official/yield"
 local gettext = dt.gettext
 
-if not du.check_min_api_version("3.0.0") then
-  dt.print("ERROR:geoJSON_export failed to load.  Lua API version 3.0.0 or later required.")
-  return
-end
+du.check_min_api_version("3.0.0", "geoJSON_export") 
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("geoJSON_export",dt.configuration.config_dir.."/lua/locale/")

--- a/contrib/geoJSON_export.lua
+++ b/contrib/geoJSON_export.lua
@@ -33,11 +33,15 @@ USAGE
 ]]
 
 local dt = require "darktable"
+local du = require "lib/dtutils"
 local df = require "lib/dtutils.file"
 require "official/yield"
 local gettext = dt.gettext
 
-dt.configuration.check_version(...,{3,0,0},{4,0,0},{5,0,0})
+if not du.check_min_api_version("3.0.0") then
+  dt.print("ERROR:geoJSON_export failed to load.  Lua API version 3.0.0 or later required.")
+  return
+end
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("geoJSON_export",dt.configuration.config_dir.."/lua/locale/")

--- a/contrib/geoToolbox.lua
+++ b/contrib/geoToolbox.lua
@@ -31,10 +31,7 @@ local df = require "lib/dtutils.file"
 require "official/yield"
 local gettext = dt.gettext
 
-if not du.check_min_api_version("3.0.0") then
-  dt.print("ERROR:geoToolbox failed to load.  Lua API version 3.0.0 or later required.")
-  return
-end
+du.check_min_api_version("3.0.0", "geoToolbox") 
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("geoToolbox",dt.configuration.config_dir.."/lua/locale/")

--- a/contrib/geoToolbox.lua
+++ b/contrib/geoToolbox.lua
@@ -26,11 +26,15 @@ require "geoToolbox"
 ]]
 
 local dt = require "darktable"
+local du = require "lib/dtutils"
 local df = require "lib/dtutils.file"
 require "official/yield"
 local gettext = dt.gettext
 
-dt.configuration.check_version(...,{3,0,0},{4,0,0},{5,0,0})
+if not du.check_min_api_version("3.0.0") then
+  dt.print("ERROR:geoToolbox failed to load.  Lua API version 3.0.0 or later required.")
+  return
+end
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("geoToolbox",dt.configuration.config_dir.."/lua/locale/")

--- a/contrib/gimp.lua
+++ b/contrib/gimp.lua
@@ -64,12 +64,16 @@
 ]]
 
 local dt = require "darktable"
+local du = require "lib/dtutils"
 local df = require "lib/dtutils.file"
 local dtsys = require "lib/dtutils.system"
 local gettext = dt.gettext
 local gimp_widget = nil
 
-dt.configuration.check_version(...,{5,0,0})
+if not du.check_min_api_version("5.0.0") then
+  dt.print("ERROR:gimp failed to load.  Lua API version 5.0.0 or greater required.")
+  return
+end
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("gimp",dt.configuration.config_dir.."/lua/locale/")

--- a/contrib/gimp.lua
+++ b/contrib/gimp.lua
@@ -70,10 +70,7 @@ local dtsys = require "lib/dtutils.system"
 local gettext = dt.gettext
 local gimp_widget = nil
 
-if not du.check_min_api_version("5.0.0") then
-  dt.print("ERROR:gimp failed to load.  Lua API version 5.0.0 or greater required.")
-  return
-end
+du.check_min_api_version("5.0.0", "gimp") 
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("gimp",dt.configuration.config_dir.."/lua/locale/")

--- a/contrib/gpx_export.lua
+++ b/contrib/gpx_export.lua
@@ -27,10 +27,7 @@ local df = require "lib/dtutils.file"
 local dl = require "lib/dtutils"
 local gettext = dt.gettext
 
-if not dl.check_min_api_version("3.0.0") then
-  dt.print("ERROR:gpx-export failed to load.  Lua API version 3.0.0 or later required.")
-  return
-end
+dl.check_min_api_version("3.0.0", "gpx-export") 
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("gpx_export",dt.configuration.config_dir.."/lua/locale/")

--- a/contrib/gpx_export.lua
+++ b/contrib/gpx_export.lua
@@ -27,7 +27,10 @@ local df = require "lib/dtutils.file"
 local dl = require "lib/dtutils"
 local gettext = dt.gettext
 
-dt.configuration.check_version(...,{3,0,0},{4,0,0},{5,0,0})
+if not dl.check_min_api_version("3.0.0") then
+  dt.print("ERROR:gpx-export failed to load.  Lua API version 3.0.0 or later required.")
+  return
+end
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("gpx_export",dt.configuration.config_dir.."/lua/locale/")

--- a/contrib/hugin.lua
+++ b/contrib/hugin.lua
@@ -36,6 +36,7 @@ This plugin will add a new storage option and calls hugin after export.
 ]]
 
 local dt = require "darktable"
+local du = require "lib/dtutils"
 local df = require "lib/dtutils.file"
 local log = require "lib/dtutils.log"
 local dtsys = require "lib/dtutils.system"
@@ -54,7 +55,10 @@ local executable_table = {"hugin", "hugin_executor", "pto_gen"}
 local PQ = dt.configuration.running_os == "windows" and '"' or "'"
 
 -- works with darktable API version from 5.0.0 on
-dt.configuration.check_version(...,{5,0,0})
+if not du.check_min_api_version("5.0.0") then
+  dt.print("ERROR:hugin failed to load.  Lua API version 5.0.0 or greater required.")
+  return
+end
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("hugin",dt.configuration.config_dir.."/lua/locale/")

--- a/contrib/hugin.lua
+++ b/contrib/hugin.lua
@@ -55,10 +55,7 @@ local executable_table = {"hugin", "hugin_executor", "pto_gen"}
 local PQ = dt.configuration.running_os == "windows" and '"' or "'"
 
 -- works with darktable API version from 5.0.0 on
-if not du.check_min_api_version("5.0.0") then
-  dt.print("ERROR:hugin failed to load.  Lua API version 5.0.0 or greater required.")
-  return
-end
+du.check_min_api_version("5.0.0", "hugin") 
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("hugin",dt.configuration.config_dir.."/lua/locale/")

--- a/contrib/image_stack.lua
+++ b/contrib/image_stack.lua
@@ -71,10 +71,7 @@ local job = nil
 local PS = dt.configuration.running_os == "windows" and "\\" or "/"
 
 -- works with LUA API version 5.0.0
-if not du.check_min_api_version("5.0.0") then
-  dt.print("ERROR:image_stack failed to load.  Lua API version 5.0.0 or greater required.")
-  return
-end
+du.check_min_api_version("5.0.0", "image_stack") 
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("image_stack",dt.configuration.config_dir.."/lua/locale/")

--- a/contrib/image_stack.lua
+++ b/contrib/image_stack.lua
@@ -71,7 +71,10 @@ local job = nil
 local PS = dt.configuration.running_os == "windows" and "\\" or "/"
 
 -- works with LUA API version 5.0.0
-dt.configuration.check_version(...,{5,0,0})
+if not du.check_min_api_version("5.0.0") then
+  dt.print("ERROR:image_stack failed to load.  Lua API version 5.0.0 or greater required.")
+  return
+end
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("image_stack",dt.configuration.config_dir.."/lua/locale/")

--- a/contrib/kml_export.lua
+++ b/contrib/kml_export.lua
@@ -37,11 +37,15 @@ USAGE
 ]]
 
 local dt = require "darktable"
+local du = require "lib/dtutils"
 local df = require "lib/dtutils.file"
 require "official/yield"
 local gettext = dt.gettext
 
-dt.configuration.check_version(...,{3,0,0},{4,0,0},{5,0,0})
+if not du.check_min_api_version("3.0.0") then
+  dt.print("ERROR:kml_export failed to load.  Lua API version 3.0.0 or later required.")
+  return
+end
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("kml_export",dt.configuration.config_dir.."/lua/locale/")

--- a/contrib/kml_export.lua
+++ b/contrib/kml_export.lua
@@ -42,10 +42,7 @@ local df = require "lib/dtutils.file"
 require "official/yield"
 local gettext = dt.gettext
 
-if not du.check_min_api_version("3.0.0") then
-  dt.print("ERROR:kml_export failed to load.  Lua API version 3.0.0 or later required.")
-  return
-end
+du.check_min_api_version("3.0.0", kml_export) 
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("kml_export",dt.configuration.config_dir.."/lua/locale/")

--- a/contrib/passport_guide.lua
+++ b/contrib/passport_guide.lua
@@ -36,9 +36,13 @@ USAGE
 ]]
 
 local dt = require "darktable"
+local du = require "lib/dtutils"
 local gettext = dt.gettext
 
-dt.configuration.check_version(...,{2,0,0},{3,0,0},{4,0,0},{5,0,0})
+if not du.check_min_api_version("2.0.0") then
+  dt.print("ERROR:passport_guide failed to load.  Lua API version 2.0.0 or later required.")
+  return
+end
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("passport_guide",dt.configuration.config_dir.."/lua/locale/")

--- a/contrib/passport_guide.lua
+++ b/contrib/passport_guide.lua
@@ -39,10 +39,7 @@ local dt = require "darktable"
 local du = require "lib/dtutils"
 local gettext = dt.gettext
 
-if not du.check_min_api_version("2.0.0") then
-  dt.print("ERROR:passport_guide failed to load.  Lua API version 2.0.0 or later required.")
-  return
-end
+du.check_min_api_version("2.0.0", "passport_guide") 
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("passport_guide",dt.configuration.config_dir.."/lua/locale/")

--- a/contrib/pdf_slideshow.lua
+++ b/contrib/pdf_slideshow.lua
@@ -57,10 +57,7 @@ if not df.check_if_bin_exists("pdflatex") then
    return
 end
 
-if not du.check_min_api_version("4.0.0") then
-  dt.print("ERROR:pdf_slideshow failed to load.  Lua API version 4.0.0 or greater required.")
-  return
-end
+du.check_min_api_version("4.0.0", "pdf_slideshow") 
 
 dt.preferences.register
    ("pdf_slideshow","open with","string",

--- a/contrib/pdf_slideshow.lua
+++ b/contrib/pdf_slideshow.lua
@@ -39,6 +39,7 @@ format (all fields can be the empty string):
 
 ]]
 local dt = require "darktable"
+local du = require "lib/dtutils"
 local df = require "lib/dtutils.file"
 require "official/yield"
 
@@ -56,7 +57,10 @@ if not df.check_if_bin_exists("pdflatex") then
    return
 end
 
-dt.configuration.check_version(...,{4,0,0},{5,0,0})
+if not du.check_min_api_version("4.0.0") then
+  dt.print("ERROR:pdf_slideshow failed to load.  Lua API version 4.0.0 or greater required.")
+  return
+end
 
 dt.preferences.register
    ("pdf_slideshow","open with","string",

--- a/contrib/quicktag.lua
+++ b/contrib/quicktag.lua
@@ -44,12 +44,16 @@ USAGE
 
 
 local dt = require "darktable"
+local du = require "lib/dtutils"
 local debug = require "darktable.debug"
 
 
 local gettext = dt.gettext
 
-dt.configuration.check_version(...,{3,0,0},{4,0,0},{5,0,0})
+if not du.check_min_api_version("3.0.0") then
+  dt.print("ERROR:quicktag failed to load.  Lua API version 3.0.0 or later required.")
+  return
+end
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("quicktag",dt.configuration.config_dir.."/lua/locale/")

--- a/contrib/quicktag.lua
+++ b/contrib/quicktag.lua
@@ -50,10 +50,7 @@ local debug = require "darktable.debug"
 
 local gettext = dt.gettext
 
-if not du.check_min_api_version("3.0.0") then
-  dt.print("ERROR:quicktag failed to load.  Lua API version 3.0.0 or later required.")
-  return
-end
+du.check_min_api_version("3.0.0", "quicktag")
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("quicktag",dt.configuration.config_dir.."/lua/locale/")

--- a/contrib/rate_group.lua
+++ b/contrib/rate_group.lua
@@ -39,9 +39,13 @@
 ]]
 
 local dt = require "darktable"
+local du = require "lib/dtutils"
 
 -- added version check
-dt.configuration.check_version(...,{3,0,0},{4,0,0},{5,0,0})
+if not du.check_min_api_version("3.0.0") then
+  dt.print("ERROR:rate_group failed to load.  Lua API version 3.0.0 or later required.")
+  return
+end
 
 local function apply_rating(rating)
   local images = dt.gui.action_images

--- a/contrib/rate_group.lua
+++ b/contrib/rate_group.lua
@@ -42,10 +42,7 @@ local dt = require "darktable"
 local du = require "lib/dtutils"
 
 -- added version check
-if not du.check_min_api_version("3.0.0") then
-  dt.print("ERROR:rate_group failed to load.  Lua API version 3.0.0 or later required.")
-  return
-end
+du.check_min_api_version("3.0.0", "rate_group") 
 
 local function apply_rating(rating)
   local images = dt.gui.action_images

--- a/contrib/rename-tags.lua
+++ b/contrib/rename-tags.lua
@@ -33,10 +33,7 @@ local du = require "lib/dtutils"
 local debug = require "darktable.debug"
 
 -- check API version
-if not du.check_min_api_version("3.0.0") then
-  darktable.print("ERROR:rename_tags failed to load.  Lua API version 3.0.0 or later required.")
-  return
-end
+du.check_min_api_version("3.0.0", "rename-tags") 
 
 -- GUI entries
 local old_tag = darktable.new_widget("entry") { tooltip = "Enter old tag" }

--- a/contrib/rename-tags.lua
+++ b/contrib/rename-tags.lua
@@ -29,7 +29,14 @@ Changes
 ]]
 
 local darktable = require "darktable"
+local du = require "lib/dtutils"
 local debug = require "darktable.debug"
+
+-- check API version
+if not du.check_min_api_version("3.0.0") then
+  darktable.print("ERROR:rename_tags failed to load.  Lua API version 3.0.0 or later required.")
+  return
+end
 
 -- GUI entries
 local old_tag = darktable.new_widget("entry") { tooltip = "Enter old tag" }

--- a/contrib/select_untagged.lua
+++ b/contrib/select_untagged.lua
@@ -19,9 +19,13 @@ Enable selection of untagged images (darktable|* tags are ignored)
 ]]
 
 local dt = require "darktable"
+local du = require "lib/dtutils"
 local gettext = dt.gettext
 
-dt.configuration.check_version(...,{3,0,0},{4,0,0},{5,0,0})
+if not du.check_min_api_version("3.0.0") then
+  dt.print("ERROR:select_untagged failed to load.  Lua API version 3.0.0 or later required.")
+  return
+end
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("select_untagged",dt.configuration.config_dir.."/lua/locale/")

--- a/contrib/select_untagged.lua
+++ b/contrib/select_untagged.lua
@@ -22,10 +22,7 @@ local dt = require "darktable"
 local du = require "lib/dtutils"
 local gettext = dt.gettext
 
-if not du.check_min_api_version("3.0.0") then
-  dt.print("ERROR:select_untagged failed to load.  Lua API version 3.0.0 or later required.")
-  return
-end
+du.check_min_api_version("3.0.0", "select_untagged") 
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("select_untagged",dt.configuration.config_dir.."/lua/locale/")

--- a/contrib/slideshowMusic.lua
+++ b/contrib/slideshowMusic.lua
@@ -25,11 +25,15 @@ USAGE
 ]]
 
 local dt = require "darktable"
+local du = require "lib/dtutils"
 local df = require "lib/dtutils.file"
 require "official/yield"
 local gettext = dt.gettext
 
-dt.configuration.check_version(...,{2,0,2},{3,0,0},{4,0,0},{5,0,0})
+if not du.check_min_api_version("2.0.2") then
+  dt.print("ERROR:slideshowMusic failed to load.  Lua API version 2.0.2 or greater required.")
+  return
+end
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("slideshowMusic",dt.configuration.config_dir.."/lua/locale/")

--- a/contrib/slideshowMusic.lua
+++ b/contrib/slideshowMusic.lua
@@ -30,10 +30,7 @@ local df = require "lib/dtutils.file"
 require "official/yield"
 local gettext = dt.gettext
 
-if not du.check_min_api_version("2.0.2") then
-  dt.print("ERROR:slideshowMusic failed to load.  Lua API version 2.0.2 or greater required.")
-  return
-end
+du.check_min_api_version("2.0.2", "slideshowMusic") 
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("slideshowMusic",dt.configuration.config_dir.."/lua/locale/")

--- a/contrib/video_mencoder.lua
+++ b/contrib/video_mencoder.lua
@@ -31,11 +31,15 @@ USAGE
 ]]
 
 local dt = require "darktable"
+local du = require "lib/dtutils"
 local df = require "lib/dtutils.file"
 require "official/yield"
 local gettext = dt.gettext
 
-dt.configuration.check_version(...,{2,0,1},{3,0,0},{4,0,0},{5,0,0})
+if not du.check_min_api_version("2.0.1") then
+  dt.print("ERROR:video_mencoder failed to load.  Lua API version 2.0.1 or later required.")
+  return
+end
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("video_mencoder",dt.configuration.config_dir.."/lua/locale/")

--- a/contrib/video_mencoder.lua
+++ b/contrib/video_mencoder.lua
@@ -36,10 +36,7 @@ local df = require "lib/dtutils.file"
 require "official/yield"
 local gettext = dt.gettext
 
-if not du.check_min_api_version("2.0.1") then
-  dt.print("ERROR:video_mencoder failed to load.  Lua API version 2.0.1 or later required.")
-  return
-end
+du.check_min_api_version("2.0.1", "video_mencoder") 
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("video_mencoder",dt.configuration.config_dir.."/lua/locale/")

--- a/examples/gettextExample.lua
+++ b/examples/gettextExample.lua
@@ -56,10 +56,7 @@ local dt = require "darktable"
 local du = require "lib/dtutils"
 
 --check API version
-if not du.check_min_api_version("3.0.0") then
-  dt.print("ERROR:gettextExample failed to load.  Lua API version 3.0.0 or greater required.")
-  return
-end
+du.check_min_api_version("3.0.0", "gettextExample")
 
 -- Not translated Text
 dt.print_error("Hello World!")

--- a/examples/gettextExample.lua
+++ b/examples/gettextExample.lua
@@ -53,7 +53,13 @@ LUA ERROR Hallo Welt!
 
 ]] 
 local dt = require "darktable"
-dt.configuration.check_version(...,{3,0,0},{4,0,0},{5,0,0}))
+local du = require "lib/dtutils"
+
+--check API version
+if not du.check_min_api_version("3.0.0") then
+  dt.print("ERROR:gettextExample failed to load.  Lua API version 3.0.0 or greater required.")
+  return
+end
 
 -- Not translated Text
 dt.print_error("Hello World!")

--- a/examples/hello_world.lua
+++ b/examples/hello_world.lua
@@ -29,10 +29,7 @@ USAGE
 local dt = require "darktable"
 local du = require "lib/dtutils"
 
-if not du.check_min_api_version("2.0.0") then
-  dt.print("ERROR:hello_world failed to load.  Lua API version 2.0.0 or greater required.")
-  return
-end
+du.check_min_api_version("2.0.0", "hello_world") 
 
 dt.print("hello, world")
 

--- a/examples/hello_world.lua
+++ b/examples/hello_world.lua
@@ -27,7 +27,12 @@ USAGE
 
 ]]
 local dt = require "darktable"
-dt.configuration.check_version(...,{2,0,0},{3,0,0},{4,0,0},{5,0,0})
+local du = require "lib/dtutils"
+
+if not du.check_min_api_version("2.0.0") then
+  dt.print("ERROR:hello_world failed to load.  Lua API version 2.0.0 or greater required.")
+  return
+end
 
 dt.print("hello, world")
 

--- a/examples/moduleExample.lua
+++ b/examples/moduleExample.lua
@@ -33,10 +33,7 @@ https://www.darktable.org/lua-api/index.html.php#darktable_new_widget
 local dt = require "darktable"
 local du = require "lib/dtutils"
 
-if not du.check_min_api_version("3.0.0") then
-  dt.print("ERROR:moduleExample failed to load.  Lua API version 3.0.0 or greater required.")
-  return
-end
+du.check_min_api_version("3.0.0", "moduleExample") 
 
 -- add a new lib
 local check_button = dt.new_widget("check_button"){label = "MyCheck_button", value = true}

--- a/examples/moduleExample.lua
+++ b/examples/moduleExample.lua
@@ -31,8 +31,12 @@ https://www.darktable.org/lua-api/index.html.php#darktable_new_widget
 ]]
 
 local dt = require "darktable"
+local du = require "lib/dtutils"
 
-dt.configuration.check_version(...,{3,0,0},{4,0,0},{5,0,0})
+if not du.check_min_api_version("3.0.0") then
+  dt.print("ERROR:moduleExample failed to load.  Lua API version 3.0.0 or greater required.")
+  return
+end
 
 -- add a new lib
 local check_button = dt.new_widget("check_button"){label = "MyCheck_button", value = true}

--- a/examples/multi_os.lua
+++ b/examples/multi_os.lua
@@ -80,12 +80,16 @@ local function _(msgid)
 end
 
 --[[
-    Specify the version(s) of the lua API that this script is compatible with.  This script uses new
-    features released in the latest version of darktable and is only compatible with the latest API version.
-    Multiple API versions may be specified, seperated by commas.
+    Check that the current api version is greater than or equal to the specified minimum.  If it's not
+    then du.check_min_api_version will print an error to the log and return false.  If the minimum api is
+    not met, then just refuse to load and return.  Optionally, you could print an error message to the 
+    screen stating that you couldn't load because the minimum api version wasn't met.
 ]]
 
-dt.configuration.check_version(...,{5,0,0})
+if not du.check_min_api_version("5.0.0") then
+  dt.print("ERROR:mulit_os failed to load:  Lua API version 5.0.0 or greater required.")
+  return
+end
 
 --[[
     copy_image_attributes is a local subroutine to copy image attributes in the database from the raw image

--- a/examples/multi_os.lua
+++ b/examples/multi_os.lua
@@ -86,10 +86,7 @@ end
     screen stating that you couldn't load because the minimum api version wasn't met.
 ]]
 
-if not du.check_min_api_version("5.0.0") then
-  dt.print("ERROR:mulit_os failed to load:  Lua API version 5.0.0 or greater required.")
-  return
-end
+du.check_min_api_version("5.0.0", "multi_os") 
 
 --[[
     copy_image_attributes is a local subroutine to copy image attributes in the database from the raw image

--- a/examples/preferenceExamples.lua
+++ b/examples/preferenceExamples.lua
@@ -24,10 +24,7 @@ USAGE
 local dt = require "darktable"
 local du = require "lib/dtutils"
 
-if not du.check_min_api_version("2.0.1") then
-  dt.print("ERROR:preferenceExamples failed to load.  Lua API version 2.0.1 or greater required.")
-  return
-end
+du.check_min_api_version("2.0.1", "preferenceExamples") 
 
 dt.preferences.register("preferenceExamples",        -- script: This is a string used to avoid name collision in preferences (i.e namespace). Set it to something unique, usually the name of the script handling the preference.
                         "preferenceExamplesString",  -- name

--- a/examples/preferenceExamples.lua
+++ b/examples/preferenceExamples.lua
@@ -22,7 +22,12 @@ USAGE
 * require this script from your main lua file
 ]] 
 local dt = require "darktable"
-dt.configuration.check_version(...,{2,0,1},{3,0,0},{4,0,0},{5,0,0})
+local du = require "lib/dtutils"
+
+if not du.check_min_api_version("2.0.1") then
+  dt.print("ERROR:preferenceExamples failed to load.  Lua API version 2.0.1 or greater required.")
+  return
+end
 
 dt.preferences.register("preferenceExamples",        -- script: This is a string used to avoid name collision in preferences (i.e namespace). Set it to something unique, usually the name of the script handling the preference.
                         "preferenceExamplesString",  -- name

--- a/examples/printExamples.lua
+++ b/examples/printExamples.lua
@@ -20,7 +20,12 @@ USAGE
 * require this file from your main lua config file:
 ]]
 local dt = require "darktable"
-dt.configuration.check_version(...,{5,0,0})
+local du = require "lib/dtutils"
+
+if not du.check_min_api_version("5.0.0") then
+  dt.print("ERROR:printExamples failed to load.  Lua API version 5.0.0 or greater required.")
+  return
+end
 
 -- Will print a string to the darktable control log (the long
 -- overlayed window that appears over the main panel).

--- a/examples/printExamples.lua
+++ b/examples/printExamples.lua
@@ -22,10 +22,7 @@ USAGE
 local dt = require "darktable"
 local du = require "lib/dtutils"
 
-if not du.check_min_api_version("5.0.0") then
-  dt.print("ERROR:printExamples failed to load.  Lua API version 5.0.0 or greater required.")
-  return
-end
+du.check_min_api_version("5.0.0", "printExamples") 
 
 -- Will print a string to the darktable control log (the long
 -- overlayed window that appears over the main panel).

--- a/examples/running_os.lua
+++ b/examples/running_os.lua
@@ -26,7 +26,12 @@ prints the operating system
 
 ]]
 local dt = require "darktable"
-dt.configuration.check_version(...,{5,0,0})
+local du = require "lib/dtutils"
+
+if not du.check_min_api_version("5.0.0") then
+  dt.print("ERROR:running_os not loaded.  Lua API version 5.0.0 or greater required.")
+  return
+end
 
 dt.print("You are running: "..dt.configuration.running_os)
 

--- a/examples/running_os.lua
+++ b/examples/running_os.lua
@@ -28,10 +28,7 @@ prints the operating system
 local dt = require "darktable"
 local du = require "lib/dtutils"
 
-if not du.check_min_api_version("5.0.0") then
-  dt.print("ERROR:running_os not loaded.  Lua API version 5.0.0 or greater required.")
-  return
-end
+du.check_min_api_version("5.0.0", "running_os") 
 
 dt.print("You are running: "..dt.configuration.running_os)
 

--- a/lib/dtutils.lua
+++ b/lib/dtutils.lua
@@ -32,7 +32,40 @@ local dt = require "darktable"
 
 local log = require "lib/dtutils.log"
 
-dt.configuration.check_version(...,{5,0,0})
+dtutils.libdoc.functions["check_min_api_version"] = {
+  Name = [[check_min_api_version]],
+  Synopsis = [[check the minimum required api version against the current api version]],
+  Usage = [[local du = require "lib/dtutils"
+
+    local result = du.check_min_api_version(min_api)
+      min_api - string - the api version that the application was written for (example: "5.0.0")]],
+  Description = [[check_min_api_version compares the minimum api required for the appllication to
+    run against the current api version.  The minimum api version is typically the api version that 
+    was current when the application was created.  If the minimum api version is not met, then an 
+    error message is printed to the log.
+
+    This function is intended to replace darktable.configuration.check_version().  The application code
+    won't have to be updated each time the api changes because this only checks the minimum version required.]],
+  Return_Value = [[result - true if the minimum api version is available, false if not.]],
+  Limitations = [[]],
+  Example = [[check_min_api_version("5.0.0") returns true if the api is greater or equal to 5.0.0 otherwise an
+    error message is printed to the log and false is returned.]],
+  See_Also = [[]],
+  Reference = [[]],
+  License = [[]],
+  Copyright = [[]],
+}
+
+function dtutils.check_min_api_version(min_api)
+  local current_api = dt.configuration.api_version_string
+  if min_api <= current_api then
+    return true
+  else
+    dt.print_error("This application is written for lua api version " .. min_api .. " or later.")
+    dt.print_error("The current lua api version is " .. current_api)
+    return false
+  end
+end
 
 dtutils.libdoc.functions["split"] = {
   Name = [[split]],

--- a/lib/dtutils.lua
+++ b/lib/dtutils.lua
@@ -37,33 +37,35 @@ dtutils.libdoc.functions["check_min_api_version"] = {
   Synopsis = [[check the minimum required api version against the current api version]],
   Usage = [[local du = require "lib/dtutils"
 
-    local result = du.check_min_api_version(min_api)
-      min_api - string - the api version that the application was written for (example: "5.0.0")]],
+    local result = du.check_min_api_version(min_api, script_name)
+      min_api - string - the api version that the application was written for (example: "5.0.0")
+      script_name - string - the name of the script]],
   Description = [[check_min_api_version compares the minimum api required for the appllication to
-    run against the current api version.  The minimum api version is typically the api version that 
-    was current when the application was created.  If the minimum api version is not met, then an 
-    error message is printed to the log.
+    run against the current api version. The minimum api version is typically the api version that 
+    was current when the application was created. If the minimum api version is not met, then an 
+    error message is printed saying the script_name failed to load, then an error is thrown causing the
+    program to stop executing. 
 
-    This function is intended to replace darktable.configuration.check_version().  The application code
+    This function is intended to replace darktable.configuration.check_version(). The application code
     won't have to be updated each time the api changes because this only checks the minimum version required.]],
   Return_Value = [[result - true if the minimum api version is available, false if not.]],
-  Limitations = [[]],
-  Example = [[check_min_api_version("5.0.0") returns true if the api is greater or equal to 5.0.0 otherwise an
-    error message is printed to the log and false is returned.]],
+  Limitations = [[When using the default handler on a script being executed from the luarc file, the error thrown
+    will stop the luarc file from executing any remaining statements. This limitation does not apply to script_manger.]],
+  Example = [[check_min_api_version("5.0.0") does nothing if the api is greater or equal to 5.0.0 otherwise an
+    error message is printed and an error is thrown stopping execution of the script.]],
   See_Also = [[]],
   Reference = [[]],
   License = [[]],
   Copyright = [[]],
 }
 
-function dtutils.check_min_api_version(min_api)
+function dtutils.check_min_api_version(min_api, script_name)
   local current_api = dt.configuration.api_version_string
-  if min_api <= current_api then
-    return true
-  else
+  if min_api > current_api then
     dt.print_error("This application is written for lua api version " .. min_api .. " or later.")
     dt.print_error("The current lua api version is " .. current_api)
-    return false
+    dt.print("ERROR:" .. script_name .. " failed to load. Lua API version " .. min_api .. " or later required.")
+    error("Minimum API " .. min_api .. " not met for " .. script_name .. ".", 0)
   end
 end
 

--- a/lib/dtutils.lua
+++ b/lib/dtutils.lua
@@ -64,7 +64,7 @@ function dtutils.check_min_api_version(min_api, script_name)
   if min_api > current_api then
     dt.print_error("This application is written for lua api version " .. min_api .. " or later.")
     dt.print_error("The current lua api version is " .. current_api)
-    dt.print("ERROR:" .. script_name .. " failed to load. Lua API version " .. min_api .. " or later required.")
+    dt.print("ERROR: " .. script_name .. " failed to load. Lua API version " .. min_api .. " or later required.")
     error("Minimum API " .. min_api .. " not met for " .. script_name .. ".", 0)
   end
 end

--- a/lib/dtutils/file.lua
+++ b/lib/dtutils/file.lua
@@ -25,9 +25,7 @@ dtutils_file.libdoc = {
 
 local gettext = dt.gettext
 
-if not du.check_min_api_version("5.0.0") then
-  return
-end
+du.check_min_api_version("5.0.0", "dtutils.file")
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("dtutils.file",dt.configuration.config_dir.."/lua/locale/")

--- a/lib/dtutils/file.lua
+++ b/lib/dtutils/file.lua
@@ -1,5 +1,6 @@
 local dtutils_file = {}
 local dt = require "darktable"
+local du = require "lib/dtutils"
 local ds = require "lib/dtutils.string"
 
 local log = require "lib/dtutils.log"
@@ -24,7 +25,9 @@ dtutils_file.libdoc = {
 
 local gettext = dt.gettext
 
-dt.configuration.check_version(...,{5,0,0})
+if not du.check_min_api_version("5.0.0") then
+  return
+end
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("dtutils.file",dt.configuration.config_dir.."/lua/locale/")

--- a/official/check_for_updates.lua
+++ b/official/check_for_updates.lua
@@ -32,10 +32,7 @@ local du = require "lib/dtutils"
 local https = require "ssl.https"
 local cjson = require "cjson"
 
-if not du.check_min_api_version("2.0.0") then
-  dt.print("ERROR:check_for_updates not loaded.  Lua API version 2.0.0 or greater required.")
-  return
-end
+du.check_min_api_version("2.0.0", "check_for_updates") 
 
 -- compare two version strings of the form "major.minor.patch"
 -- returns -1, 0, 1 if the first version is smaller, equal, greater than the second version,

--- a/official/check_for_updates.lua
+++ b/official/check_for_updates.lua
@@ -28,10 +28,14 @@ USAGE
 ]]
 
 local dt = require "darktable"
+local du = require "lib/dtutils"
 local https = require "ssl.https"
 local cjson = require "cjson"
 
-dt.configuration.check_version(...,{2,0,0},{3,0,0},{4,0,0},{5,0,0})
+if not du.check_min_api_version("2.0.0") then
+  dt.print("ERROR:check_for_updates not loaded.  Lua API version 2.0.0 or greater required.")
+  return
+end
 
 -- compare two version strings of the form "major.minor.patch"
 -- returns -1, 0, 1 if the first version is smaller, equal, greater than the second version,

--- a/official/copy_paste_metadata.lua
+++ b/official/copy_paste_metadata.lua
@@ -26,8 +26,12 @@ USAGE
 ]]
 
 local dt = require "darktable"
+local du = require "lib/dtutils"
 
-dt.configuration.check_version(...,{3,0,0},{4,0,0},{5,0,0})
+if not du.check_min_api_version("3.0.0") then
+  dt.print("ERROR:copy_paste_metadata not loaded.  Lua API version 3.0.0 or greater required.")
+  return
+end
 
 -- set this to "false" if you don't want to overwrite metadata fields
 -- (title, description, creator, publisher and rights) that are already set

--- a/official/copy_paste_metadata.lua
+++ b/official/copy_paste_metadata.lua
@@ -28,10 +28,7 @@ USAGE
 local dt = require "darktable"
 local du = require "lib/dtutils"
 
-if not du.check_min_api_version("3.0.0") then
-  dt.print("ERROR:copy_paste_metadata not loaded.  Lua API version 3.0.0 or greater required.")
-  return
-end
+du.check_min_api_version("3.0.0", "copy_paste_metadata")
 
 -- set this to "false" if you don't want to overwrite metadata fields
 -- (title, description, creator, publisher and rights) that are already set

--- a/official/delete_long_tags.lua
+++ b/official/delete_long_tags.lua
@@ -29,7 +29,12 @@ all tags longer than the given length will be automatically deleted at every res
 ]]
 
 local dt = require "darktable"
-dt.configuration.check_version(...,{2,0,0},{3,0,0},{4,0,0},{5,0,0})
+local du = require "lib/dtutils"
+
+if not du.check_min_api_version("2.0.0") then
+  dt.print("ERROR:delete_long_tags not loaded.  Lua API version 2.0.0 or greater required.")
+  return
+end
 
 dt.preferences.register("delete_long_tags", "length", "integer",
                         "maximum length of tags to keep",

--- a/official/delete_long_tags.lua
+++ b/official/delete_long_tags.lua
@@ -31,10 +31,7 @@ all tags longer than the given length will be automatically deleted at every res
 local dt = require "darktable"
 local du = require "lib/dtutils"
 
-if not du.check_min_api_version("2.0.0") then
-  dt.print("ERROR:delete_long_tags not loaded.  Lua API version 2.0.0 or greater required.")
-  return
-end
+du.check_min_api_version("2.0.0", "delete_long_tags") 
 
 dt.preferences.register("delete_long_tags", "length", "integer",
                         "maximum length of tags to keep",

--- a/official/delete_unused_tags.lua
+++ b/official/delete_unused_tags.lua
@@ -29,10 +29,7 @@ all tags that are not used will be automatically deleted at every restart
 local dt = require "darktable"
 local du = require "lib/dtutils"
 
-if not du.check_min_api_version("5.0.0") then
-  dt.print("ERROR:delete_unused_tags not loaded.  Lua API version 5.0.0 or greater required.")
-  return
-end
+du.check_min_api_version("5.0.0", "delete_unused_tags") 
 
 -- deleting while iterating the tags list seems to break the iterator!
 local unused_tags = {}

--- a/official/delete_unused_tags.lua
+++ b/official/delete_unused_tags.lua
@@ -27,8 +27,12 @@ all tags that are not used will be automatically deleted at every restart
 ]]
 
 local dt = require "darktable"
+local du = require "lib/dtutils"
 
-dt.configuration.check_version(...,{5,0,0})
+if not du.check_min_api_version("5.0.0") then
+  dt.print("ERROR:delete_unused_tags not loaded.  Lua API version 5.0.0 or greater required.")
+  return
+end
 
 -- deleting while iterating the tags list seems to break the iterator!
 local unused_tags = {}

--- a/official/enfuse.lua
+++ b/official/enfuse.lua
@@ -38,10 +38,7 @@ local df = require "lib/dtutils.file"
 require "official/yield"
 local gettext = dt.gettext
 
-if not du.check_min_api_version("3.0.0") then
-  dt.print("ERROR:enfuse not loaded.  Lua API version 3.0.0 or greater required.")
-  return
-end
+du.check_min_api_version("3.0.0", "enfuse")
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("enfuse",dt.configuration.config_dir.."/lua/locale/")

--- a/official/enfuse.lua
+++ b/official/enfuse.lua
@@ -33,11 +33,15 @@ TODO
 ]]
 
 local dt = require "darktable"
+local du = require "lib/dtutils"
 local df = require "lib/dtutils.file"
 require "official/yield"
 local gettext = dt.gettext
 
-dt.configuration.check_version(...,{3,0,0},{4,0,0},{5,0,0})
+if not du.check_min_api_version("3.0.0") then
+  dt.print("ERROR:enfuse not loaded.  Lua API version 3.0.0 or greater required.")
+  return
+end
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("enfuse",dt.configuration.config_dir.."/lua/locale/")

--- a/official/generate_image_txt.lua
+++ b/official/generate_image_txt.lua
@@ -35,10 +35,14 @@ USAGE
 --  * make filenames with double quotes (") work
 
 local dt = require "darktable"
+local du = require "lib/dtutils"
 require "darktable.debug"
 require "official/yield"
 
-dt.configuration.check_version(...,{2,1,0},{3,0,0},{4,0,0},{5,0,0})
+if not du.check_min_api_version("2.1.0") then
+  dt.print("ERROR:generate_image_txt not loaded.  Lua API version 2.1.0 or greater required.")
+  return
+end
 
 dt.preferences.register("generate_image_txt",
                         "enabled",

--- a/official/generate_image_txt.lua
+++ b/official/generate_image_txt.lua
@@ -39,10 +39,7 @@ local du = require "lib/dtutils"
 require "darktable.debug"
 require "official/yield"
 
-if not du.check_min_api_version("2.1.0") then
-  dt.print("ERROR:generate_image_txt not loaded.  Lua API version 2.1.0 or greater required.")
-  return
-end
+du.check_min_api_version("2.1.0", "generate_image_txt") 
 
 dt.preferences.register("generate_image_txt",
                         "enabled",

--- a/official/image_path_in_ui.lua
+++ b/official/image_path_in_ui.lua
@@ -31,10 +31,7 @@ This plugin will add a widget at the bottom of the left column in lighttable mod
 local dt = require "darktable"
 local du = require "lib/dtutils"
 
-if not du.check_min_api_version("2.0.0") then
-  dt.print("ERROR:image_path_in_ui not loaded.  Lua API version 2.0.0 or greater required.")
-  return
-end
+du.check_min_api_version("2.0.0", "image_path_in_ui") 
 
 local main_label = dt.new_widget("label"){selectable = true, ellipsize = "middle", halign = "start"}
 

--- a/official/image_path_in_ui.lua
+++ b/official/image_path_in_ui.lua
@@ -29,7 +29,12 @@ This plugin will add a widget at the bottom of the left column in lighttable mod
 
 ]]
 local dt = require "darktable"
-dt.configuration.check_version(...,{2,0,0},{3,0,0},{4,0,0},{5,0,0})
+local du = require "lib/dtutils"
+
+if not du.check_min_api_version("2.0.0") then
+  dt.print("ERROR:image_path_in_ui not loaded.  Lua API version 2.0.0 or greater required.")
+  return
+end
 
 local main_label = dt.new_widget("label"){selectable = true, ellipsize = "middle", halign = "start"}
 

--- a/official/save_selection.lua
+++ b/official/save_selection.lua
@@ -34,7 +34,12 @@ increase it if you need more temporary selection buffers
 
 ]]
 local dt = require "darktable"
-dt.configuration.check_version(...,{2,0,0},{3,0,0},{4,0,0},{5,0,0})
+local du = require "lib/dtutils"
+
+if not du.check_min_api_version("2.0.0") then
+  dt.print("ERROR:save_selection not loaded.  Lua API version 2.0.0 or greater required.")
+  return
+end
 
 local buffer_count = 5
 

--- a/official/save_selection.lua
+++ b/official/save_selection.lua
@@ -36,10 +36,7 @@ increase it if you need more temporary selection buffers
 local dt = require "darktable"
 local du = require "lib/dtutils"
 
-if not du.check_min_api_version("2.0.0") then
-  dt.print("ERROR:save_selection not loaded.  Lua API version 2.0.0 or greater required.")
-  return
-end
+du.check_min_api_version("2.0.0", "save_selection") 
 
 local buffer_count = 5
 

--- a/official/selection_to_pdf.lua
+++ b/official/selection_to_pdf.lua
@@ -34,9 +34,13 @@ Plugin allows you to choose how many thumbnails you need per row
 
 ]]
 local dt = require "darktable"
+local du = require "lib/dtutils"
 require "official/yield"
 
-dt.configuration.check_version(...,{2,0,0},{3,0,0},{4,0,0},{5,0,0})
+if not du.check_min_api_version("2.0.0") then
+  dt.print("ERROR:selection_to_pdf not loaded.  Lua API version 2.0.0 or greater required.")
+  return
+end
 
 dt.preferences.register
    ("selection_to_pdf","Open with","string",

--- a/official/selection_to_pdf.lua
+++ b/official/selection_to_pdf.lua
@@ -37,10 +37,7 @@ local dt = require "darktable"
 local du = require "lib/dtutils"
 require "official/yield"
 
-if not du.check_min_api_version("2.0.0") then
-  dt.print("ERROR:selection_to_pdf not loaded.  Lua API version 2.0.0 or greater required.")
-  return
-end
+du.check_min_api_version("2.0.0", "selection_to_pdf")
 
 dt.preferences.register
    ("selection_to_pdf","Open with","string",

--- a/tools/executable_manager.lua
+++ b/tools/executable_manager.lua
@@ -32,6 +32,8 @@ local dt = require "darktable"
 local du = require "lib/dtutils"
 local df = require "lib/dtutils.file"
 
+du.check_min_api_version("5.0.0", "executable_manager")
+
 local PS = dt.configuration.running_os == "windows" and "\\" or "/"
 
 local gettext = dt.gettext

--- a/tools/gen_i18n_mo.lua
+++ b/tools/gen_i18n_mo.lua
@@ -30,6 +30,8 @@ local df = require "lib/dtutils.file"
 local log = require "lib/dtutils.log"
 local dtsys = require "lib/dtutils.system"
 
+du.check_min_api_version("5.0.0", "gen_I18n_mo")
+
 -- figure out the path separator
 
 local PS = dt.configuration.running_os == "windows" and "\\" or "/"

--- a/tools/get_lib_manpages.lua
+++ b/tools/get_lib_manpages.lua
@@ -10,7 +10,10 @@ local df = require "lib/dtutils.file"
 local log = require "lib/dtutils.log"
 local libname = nil
 
-dt.configuration.check_version(...,{3,0,0},{4,0,0},{5,0,0})
+if not du.check_min_api_version("3.0.0") then
+  dt.print("ERROR: get_lib_manpages failed to load.  Lua API version 3.0.0 or greater required.")
+  return 
+end
 
 local keys = {"Name", "Synopsis", "Usage", "Description", "Return_Value", "Limitations", 
               "Example", "See_Also", "Reference", "License", "Copyright"}

--- a/tools/get_lib_manpages.lua
+++ b/tools/get_lib_manpages.lua
@@ -10,10 +10,7 @@ local df = require "lib/dtutils.file"
 local log = require "lib/dtutils.log"
 local libname = nil
 
-if not du.check_min_api_version("3.0.0") then
-  dt.print("ERROR: get_lib_manpages failed to load.  Lua API version 3.0.0 or greater required.")
-  return 
-end
+du.check_min_api_version("3.0.0", "get_lib_manpages") 
 
 local keys = {"Name", "Synopsis", "Usage", "Description", "Return_Value", "Limitations", 
               "Example", "See_Also", "Reference", "License", "Copyright"}

--- a/tools/get_libdoc.lua
+++ b/tools/get_libdoc.lua
@@ -5,8 +5,12 @@
 ]]
 
 local dt = require "darktable"
+local du = require "lib/dtutils"
 
-dt.configuration.check_version(...,{3,0,0},{4,0,0},{5,0,0})
+if not du.check_min_api_version("3.0.0") then
+  dt.print("ERROR: get_libdoc failed to load.  Lua API version 3.0.0 or greater required.")
+  return 
+end
 
 local keys = {"Name", "Synopsis", "Usage", "Description", "Return_Value", "Limitations", 
               "Example", "See_Also", "Reference", "License", "Copyright"}

--- a/tools/get_libdoc.lua
+++ b/tools/get_libdoc.lua
@@ -7,10 +7,7 @@
 local dt = require "darktable"
 local du = require "lib/dtutils"
 
-if not du.check_min_api_version("3.0.0") then
-  dt.print("ERROR: get_libdoc failed to load.  Lua API version 3.0.0 or greater required.")
-  return 
-end
+du.check_min_api_version("3.0.0", "get_libdoc") 
 
 local keys = {"Name", "Synopsis", "Usage", "Description", "Return_Value", "Limitations", 
               "Example", "See_Also", "Reference", "License", "Copyright"}

--- a/tools/plugin_manager.lua
+++ b/tools/plugin_manager.lua
@@ -1,0 +1,1 @@
+/home/bill/src/plugins/lua-scripts/tools/plugin_manager.lua

--- a/tools/script_manager.lua
+++ b/tools/script_manager.lua
@@ -455,7 +455,10 @@ end
 
 -- api check
 
-dt.configuration.check_version(...,{5,0,0})
+if not du.check_min_api_version("5.0.0") then
+  dt.print("ERROR:script_manager failed to load.  Lua API version 5.0.0 or greater required.")
+  return
+end
 
 -- set up tables to contain all the widgets and choices
 

--- a/tools/script_manager.lua
+++ b/tools/script_manager.lua
@@ -455,10 +455,7 @@ end
 
 -- api check
 
-if not du.check_min_api_version("5.0.0") then
-  dt.print("ERROR:script_manager failed to load.  Lua API version 5.0.0 or greater required.")
-  return
-end
+du.check_min_api_version("5.0.0")
 
 -- set up tables to contain all the widgets and choices
 


### PR DESCRIPTION
Added check_min_api_version function to dtutils.lua to check the minimum version of the lua API required for a script to run.  This is intended to replace the API check done with darktable.configuration.check_version(), which requires changing each time the API version changes.  check_min_api_version should work for all API version changes unless backward compatibility is broken.  All the scripts using darktable.configuration.check_version() were changed to use check_min_api_version().  check_min_api_version returns true or false letting the author deal with the result appropriately rather than raising an error which would stop further processing or loading by the luarc file.