### PR TITLE
executable manager windows string spllit bug

### DIFF
--- a/tools/executable_manager.lua
+++ b/tools/executable_manager.lua
@@ -112,7 +112,7 @@ local exec_table = {}
 
 for _,pref  in ipairs(matches) do
   local parts = du.split(pref, "=")
-  local tmp = du.split(parts[1], PS)
+  local tmp = du.split(parts[1], "/") -- preferences are stored with forward slashes
   table.insert(exec_table, tmp[#tmp])
 end
 


### PR DESCRIPTION
Fixed bug that caused the lua executale path to not split correctly on windows, causing a growing list of longer and longer executable path preferences which ultimately results in a darktable crash.  Preferences are stored internally with forward slashes, not O/S specific path separators, so changed the executable path split to use a forward slash.