### PR TITLE
mkdir/rmdir : handle path with spaces

### DIFF
--- a/lib/dtutils/file.lua
+++ b/lib/dtutils/file.lua
@@ -579,7 +579,7 @@ dtutils_file.libdoc.functions["mkdir"] = {
 function dtutils_file.mkdir(path) 
   if not dtutils_file.check_if_file_exists(path) then
     local mkdir_cmd = dt.configuration.running_os == "windows" and "mkdir" or "mkdir -p"
-    return dsys.external_command(mkdir_cmd.." "..path)
+    return dsys.external_command(mkdir_cmd.." \""..path.."\"")
   else
     return 0
   end
@@ -604,7 +604,7 @@ dtutils_file.libdoc.functions["rmdir"] = {
 
 function dtutils_file.rmdir(path)
   local rm_cmd = dt.configuration.running_os == "windows" and "rmdir /S /Q" or "rm -r"
-  return dsys.external_command(rm_cmd.." "..path)
+  return dsys.external_command(rm_cmd.." \""..path.."\"")
 end
 
 


### PR DESCRIPTION
be careful, I've absolutely no idea if this break something on other platforms than linux