### PR TITLE
Update face_recognition for tolerance and locales

### DIFF
--- a/contrib/face_recognition.lua
+++ b/contrib/face_recognition.lua
@@ -235,9 +235,11 @@ local function face_recognition ()
       -- Get path of exported images
       local path = df.get_path (img_list[1])
       dt.print_log ("Face recognition: Path to unknown images: " .. path)
-
+      os.setlocale("C")
       local tolerance = dt.preferences.read(MODULE, "tolerance", "float")
+      
       local command = bin_path ..  " --cpus " .. nrCores .. " --tolerance " .. tolerance .. " " .. knownPath .. " " .. path .. " > " .. OUTPUT
+      os.setlocale()
       dt.print_log("Face recognition: Running command: " .. command)
       dt.print(_("Starting face recognition..."))
 


### PR DESCRIPTION
When locales use comma for numeric decimal separator, tolerance argument is not passed correctly.
I propose to switch temporally to "C" locales before converting float tolerance to string to get a period decimal separator.
Related to issue "lua script face_recognition - small issue #210".
Many thanks,
Yvan