### PR TITLE
Add an exporthaldclut lighttable module

### DIFF
--- a/contrib/exportLUT.lua
+++ b/contrib/exportLUT.lua
@@ -83,7 +83,7 @@ local function export_luts()
       dt.styles.apply(style, identity)
       
       local io_lut = dt.new_format("png")
-      io_lut.bpp = 16
+      io_lut.bpp = 8
       io_lut:write_image(identity, export_chooser_button.value .. os_path_seperator .. style.name .. ".png")
       count = count + 1
       job.percent = count / size

--- a/contrib/exportLUT.lua
+++ b/contrib/exportLUT.lua
@@ -33,7 +33,7 @@ https://www.darktable.org/lua-api/index.html.php#darktable_new_widget
 local dt = require "darktable"
 local du = require "lib/dtutils"
 
-du.check_min_api_version("3.0.0", "moduleExample") 
+du.check_min_api_version("3.0.0", "exportLUT") 
 
 -- add a new lib
 
@@ -63,7 +63,27 @@ local output_label = dt.new_widget("label"){
   label = "choose the output location"
 }
 
-local separator = dt.new_widget("separator"){}
+local separator = dt.new_widget("separator"){
+  
+}
+
+local function create_lut(style, haldclut)
+  haldclut.reset
+  dt.styles.apply(style, haldclut)
+end
+
+local function export_lut(haldclut)
+  
+end
+
+local function export_luts()
+  identity = dt.database.import(file_chooser_button)
+  for style_num, style in ipairs(dt.styles) do
+    identity = create_lut(style, identity)
+    export_lut(identity)
+    dt.print(style.name)
+  end
+end
 
 if (dt.configuration.api_version_major >= 6) then
   local section_label = dt.new_widget("section_label")
@@ -117,9 +137,7 @@ else
       dt.new_widget("button")
       {
         label = "export",
-        clicked_callback = function (_)
-          dt.print("Button clicked")
-        end
+        clicked_callback = export_luts
       }
     },
     nil,-- view_enter

--- a/contrib/exportLUT.lua
+++ b/contrib/exportLUT.lua
@@ -33,6 +33,12 @@ local ds = require("lib/dtutils.system")
 
 local gettext = dt.gettext
 
+gettext.bindtextdomain("exportLUT",dt.configuration.config_dir.."/lua/locale/")
+
+local function _(msgid)
+    return gettext.dgettext("exportLUT", msgid)
+end
+
 du.check_min_api_version("5.0.0", "exportLUT") 
 
 -- Thanks Kevin Ertel for this bit
@@ -42,27 +48,27 @@ local mkdir_command = 'mkdir -p '
 if dt.configuration.running_os == 'windows' then mkdir_command = 'mkdir ' end
 
 local file_chooser_button = dt.new_widget("file_chooser_button"){
-    title = gettext.gettext("Identity_file_chooser"),
+    title = _("Identity_file_chooser"),
     value = "",
     is_directory = false
 }
 
 local export_chooser_button = dt.new_widget("file_chooser_button"){
-    title = gettext.gettext("Export_location_chooser"),
+    title = _("Export_location_chooser"),
     value = "",
     is_directory = true
 }
 
 local identity_label = dt.new_widget("label"){
-  label = gettext.gettext("choose the identity haldclut file")
+  label = _("choose the identity haldclut file")
 }
 
 local output_label = dt.new_widget("label"){
-  label = gettext.gettext("choose the output location")
+  label = _("choose the output location")
 }
 
 local warning_label = dt.new_widget("label"){
-  label = gettext.gettext("WARNING: files may be silently overwritten")
+  label = _("WARNING: files may be silently overwritten")
 }
 
 local function end_job(job)
@@ -84,9 +90,9 @@ end
 local function export_luts()
   local identity = dt.database.import(file_chooser_button.value)
   if(type(identity) ~= "userdata") then
-    dt.print(gettext.gettext("Invalid identity lut file"))
+    dt.print(_("Invalid identity lut file"))
   else
-    local job = dt.gui.create_job(gettext.gettext('Exporting styles as haldCLUTs'), true, end_job)
+    local job = dt.gui.create_job(_('Exporting styles as haldCLUTs'), true, end_job)
     
     local size = 1
 
@@ -105,22 +111,22 @@ local function export_luts()
       io_lut:write_image(identity, output_path(style.name, job))
       count = count + 1
       job.percent = count / size
-      dt.print(gettext.gettext("Exported: ") .. output_path(style.name, job))
+      dt.print(_("Exported: ") .. output_path(style.name, job))
     end
-    dt.print(gettext.gettext("Done exporting haldCLUTs"))
+    dt.print(_("Done exporting haldCLUTs"))
     job.valid = false
     identity:reset()
   end
 end
 
 local export_button = dt.new_widget("button"){
-  label = gettext.gettext("export"),
+  label = _("export"),
   clicked_callback = export_luts
 }
 
 dt.register_lib(
-  gettext.gettext("export haldclut"),
-  gettext.gettext("export haldclut"),
+  _("export haldclut"),
+  _("export haldclut"),
   true,
   false,
   {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 100}},

--- a/contrib/exportLUT.lua
+++ b/contrib/exportLUT.lua
@@ -83,45 +83,22 @@ local export_button = dt.new_widget("button"){
   clicked_callback = export_luts
 }
 
-if (dt.configuration.api_version_major >= 6) then
-
-  dt.register_lib(
-    "export haldclut",
-    "export haldclut",
-    true,
-    false,
-    {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 100}},
+dt.register_lib(
+  "export haldclut",
+  "export haldclut",
+  true,
+  false,
+  {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 100}},
+  dt.new_widget("box")
+  {
+    orientation = "vertical",
     identity_label,
     file_chooser_button,
     output_label,
     export_chooser_button,
     warning_label,
-    dt.new_widget("box")
-    {
-      orientation = "vertical",
-      export_button
-    },
-    nil,
-    nil
-  )
-else
-  dt.register_lib(
-    "export haldclut",
-    "export haldclut",
-    true,
-    false,
-    {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 100}},
-    dt.new_widget("box")
-    {
-      orientation = "vertical",
-      identity_label,
-      file_chooser_button,
-      output_label,
-      export_chooser_button,
-      warning_label,
-      export_button
-    },
-    nil,
-    nil
-  )
-end
+    export_button
+  },
+  nil,
+  nil
+)

--- a/contrib/exportLUT.lua
+++ b/contrib/exportLUT.lua
@@ -17,7 +17,7 @@
 ]]
 --[[
 Add the following line to .config/darktable/luarc to enable this lightable module: 
-  require "exportLut"
+  require "contrib/exportLut"
 
 Given a haldCLUT identity file this script generates haldCLUTS from all the user's
 styles and exports them to a location of their choosing.

--- a/contrib/exportLUT.lua
+++ b/contrib/exportLUT.lua
@@ -1,0 +1,131 @@
+--[[
+    This file is part of darktable,
+    copyright (c) 2016 Tobias Jakobs
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+     but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+]]
+--[[
+
+USAGE
+* require this script from your main lua file
+  To do this add this line to the file .config/darktable/luarc: 
+require "moduleExample"
+
+* it creates a new example lighttable module
+
+More informations about building user interface elements:
+https://www.darktable.org/usermanual/ch09.html.php#lua_gui_example
+And about new_widget here:
+https://www.darktable.org/lua-api/index.html.php#darktable_new_widget
+]]
+
+local dt = require "darktable"
+local du = require "lib/dtutils"
+
+du.check_min_api_version("3.0.0", "moduleExample") 
+
+-- add a new lib
+
+local combobox = dt.new_widget("combobox"){label = "on conflict", value = 1, "skip", "overwrite"}
+
+--https://www.darktable.org/lua-api/ar01s02s54.html.php
+
+local file_chooser_button = dt.new_widget("file_chooser_button")
+{
+    title = "Identity_file_chooser",  -- The title of the window when choosing a file
+    value = "",                       -- The currently selected file
+    is_directory = false              -- True if the file chooser button only allows directories to be selecte
+}
+
+local export_chooser_button = dt.new_widget("file_chooser_button")
+{
+    title = "Export_location_chooser",  -- The title of the window when choosing a file
+    value = "",                       -- The currently selected file
+    is_directory = true              -- True if the file chooser button only allows directories to be selecte
+}
+
+local identity_label = dt.new_widget("label"){
+  label = "choose the identity haldclut file"
+}
+
+local output_label = dt.new_widget("label"){
+  label = "choose the output location"
+}
+
+local separator = dt.new_widget("separator"){}
+
+if (dt.configuration.api_version_major >= 6) then
+  local section_label = dt.new_widget("section_label")
+  {
+    label = "MySectionLabel"
+  }
+
+  dt.register_lib(
+    "export haldclut",     -- Module name
+    "export haldclut",     -- name
+    true,                -- expandable
+    false,               -- resetable
+    {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 100}},   -- containers
+    identity_label,
+    file_chooser_button,
+    output_label,
+    export_chooser_button,
+    combobox,
+    separator,
+    dt.new_widget("box") -- widget
+    {
+      orientation = "vertical",
+      dt.new_widget("button")
+      {
+        label = "export",
+        clicked_callback = function (_)
+          dt.print("Button clicked")
+        end
+      },
+	  section_label
+    },
+    nil,-- view_enter
+    nil -- view_leave
+  )
+else
+  dt.register_lib(
+    "export haldclut",     -- Module name
+    "export haldclut",     -- name
+    true,                -- expandable
+    false,               -- resetable
+    {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 100}},   -- containers
+    dt.new_widget("box") -- widget
+    {
+      orientation = "vertical",
+      identity_label,
+      file_chooser_button,
+      output_label,
+      export_chooser_button,
+      combobox,
+      separator,
+      dt.new_widget("button")
+      {
+        label = "export",
+        clicked_callback = function (_)
+          dt.print("Button clicked")
+        end
+      }
+    },
+    nil,-- view_enter
+    nil -- view_leave
+  )
+end
+
+-- vim: shiftwidth=2 expandtab tabstop=2 cindent syntax=lua
+-- kate: hl Lua;

--- a/contrib/exportLUT.lua
+++ b/contrib/exportLUT.lua
@@ -55,24 +55,32 @@ local output_label = dt.new_widget("label"){
   label = "choose the output location"
 }
 
-local export_button = dt.new_widget("button"){
-  label = "export",
-  clicked_callback = export_luts
+local warning_label = dt.new_widget("label"){
+  label = "WARNING: files may be silently overwritten"
 }
 
 local function export_luts()
   identity = dt.database.import(file_chooser_button.value)
-  for style_num, style in ipairs(dt.styles) do
-    
+  if(type(identity) ~= "userdata") then
+    dt.print("Invalid identity lut file")
+  else
+    for style_num, style in ipairs(dt.styles) do
+      
+      identity:reset()
+      dt.styles.apply(style, identity)
+      
+      io_lut = dt.new_format("png")
+      dt.print("Exporting: " .. export_chooser_button.value .. os_path_seperator .. style.name .. ".png")
+      io_lut:write_image(identity, export_chooser_button.value .. os_path_seperator .. style.name .. ".png")
+    end
     identity:reset()
-    dt.styles.apply(style, identity)
-    
-    io_lut = dt.new_format("png")
-    dt.print("Exporting: " .. export_chooser_button.value .. os_path_seperator .. style.name .. ".png")
-    io_lut:write_image(identity, export_chooser_button.value .. os_path_seperator .. style.name .. ".png")
   end
-  identity:reset()
 end
+
+local export_button = dt.new_widget("button"){
+  label = "export",
+  clicked_callback = export_luts
+}
 
 if (dt.configuration.api_version_major >= 6) then
 
@@ -86,6 +94,7 @@ if (dt.configuration.api_version_major >= 6) then
     file_chooser_button,
     output_label,
     export_chooser_button,
+    warning_label,
     dt.new_widget("box")
     {
       orientation = "vertical",
@@ -108,6 +117,7 @@ else
       file_chooser_button,
       output_label,
       export_chooser_button,
+      warning_label,
       export_button
     },
     nil,

--- a/contrib/exportLUT.lua
+++ b/contrib/exportLUT.lua
@@ -29,7 +29,7 @@ overwritten silently.
 local dt = require "darktable"
 local du = require "lib/dtutils"
 
-du.check_min_api_version("3.0.0", "exportLUT") 
+du.check_min_api_version("5.0.0", "exportLUT") 
 
 -- Thanks Kevin Ertel for this bit
 local os_path_seperator = '/'
@@ -70,8 +70,9 @@ local function export_luts()
       dt.styles.apply(style, identity)
       
       io_lut = dt.new_format("png")
-      dt.print("Exporting: " .. export_chooser_button.value .. os_path_seperator .. style.name .. ".png")
+      io_lut.bpp = 16
       io_lut:write_image(identity, export_chooser_button.value .. os_path_seperator .. style.name .. ".png")
+      dt.print("Exported: " .. export_chooser_button.value .. os_path_seperator .. style.name .. ".png")
     end
     identity:reset()
   end

--- a/contrib/exportLUT.lua
+++ b/contrib/exportLUT.lua
@@ -59,21 +59,38 @@ local warning_label = dt.new_widget("label"){
   label = "WARNING: files may be silently overwritten"
 }
 
+local function end_job(job)
+  job.valid = false
+end
+
 local function export_luts()
-  identity = dt.database.import(file_chooser_button.value)
+  local identity = dt.database.import(file_chooser_button.value)
   if(type(identity) ~= "userdata") then
     dt.print("Invalid identity lut file")
   else
+    local job = dt.gui.create_job('Exporting styles as haldCLUTs', true, end_job)
+    
+    local size = 1
+
+    for style_num, style in ipairs(dt.styles) do
+      size = size + 1
+    end
+
+    local count = 0
     for style_num, style in ipairs(dt.styles) do
       
       identity:reset()
       dt.styles.apply(style, identity)
       
-      io_lut = dt.new_format("png")
+      local io_lut = dt.new_format("png")
       io_lut.bpp = 16
       io_lut:write_image(identity, export_chooser_button.value .. os_path_seperator .. style.name .. ".png")
+      count = count + 1
+      job.percent = count / size
       dt.print("Exported: " .. export_chooser_button.value .. os_path_seperator .. style.name .. ".png")
     end
+    dt.print("Done exporting haldCLUTs")
+    job.valid = false
     identity:reset()
   end
 end

--- a/contrib/exportLUT.lua
+++ b/contrib/exportLUT.lua
@@ -35,11 +35,11 @@ local du = require "lib/dtutils"
 
 du.check_min_api_version("3.0.0", "exportLUT") 
 
--- add a new lib
+-- Thanks Kevin Ertel for this trick
+local os_path_seperator = '/'
+if dt.configuration.running_os == 'windows' then os_path_seperator = '\\' end
 
 local combobox = dt.new_widget("combobox"){label = "on conflict", value = 1, "skip", "overwrite"}
-
---https://www.darktable.org/lua-api/ar01s02s54.html.php
 
 local file_chooser_button = dt.new_widget("file_chooser_button")
 {
@@ -64,24 +64,20 @@ local output_label = dt.new_widget("label"){
 }
 
 local separator = dt.new_widget("separator"){
-  
 }
 
-local function create_lut(style, haldclut)
-  haldclut.reset
-  dt.styles.apply(style, haldclut)
-end
-
-local function export_lut(haldclut)
-  
-end
-
 local function export_luts()
-  identity = dt.database.import(file_chooser_button)
+  identity = dt.database.import(file_chooser_button.value)
   for style_num, style in ipairs(dt.styles) do
-    identity = create_lut(style, identity)
-    export_lut(identity)
-    dt.print(style.name)
+    
+    identity:reset()
+    dt.styles.apply(style, identity)
+    
+    io_lut = dt.new_format("png")
+    dt.print(export_chooser_button.value .. os_path_seperator .. style.name)
+    io_lut:write_image(identity, export_chooser_button.value .. os_path_seperator .. style.name)
+    
+    dt.print(export_chooser_button.value .. os_path_seperator .. style.name)
   end
 end
 

--- a/contrib/exportLUT.lua
+++ b/contrib/exportLUT.lua
@@ -31,6 +31,8 @@ local du = require "lib/dtutils"
 local df = require("lib/dtutils.file")
 local ds = require("lib/dtutils.system")
 
+local gettext = dt.gettext
+
 du.check_min_api_version("5.0.0", "exportLUT") 
 
 -- Thanks Kevin Ertel for this bit
@@ -40,27 +42,27 @@ local mkdir_command = 'mkdir -p '
 if dt.configuration.running_os == 'windows' then mkdir_command = 'mkdir ' end
 
 local file_chooser_button = dt.new_widget("file_chooser_button"){
-    title = "Identity_file_chooser",
+    title = gettext.gettext("Identity_file_chooser"),
     value = "",
     is_directory = false
 }
 
 local export_chooser_button = dt.new_widget("file_chooser_button"){
-    title = "Export_location_chooser",
+    title = gettext.gettext("Export_location_chooser"),
     value = "",
     is_directory = true
 }
 
 local identity_label = dt.new_widget("label"){
-  label = "choose the identity haldclut file"
+  label = gettext.gettext("choose the identity haldclut file")
 }
 
 local output_label = dt.new_widget("label"){
-  label = "choose the output location"
+  label = gettext.gettext("choose the output location")
 }
 
 local warning_label = dt.new_widget("label"){
-  label = "WARNING: files may be silently overwritten"
+  label = gettext.gettext("WARNING: files may be silently overwritten")
 }
 
 local function end_job(job)
@@ -82,9 +84,9 @@ end
 local function export_luts()
   local identity = dt.database.import(file_chooser_button.value)
   if(type(identity) ~= "userdata") then
-    dt.print("Invalid identity lut file")
+    dt.print(gettext.gettext("Invalid identity lut file"))
   else
-    local job = dt.gui.create_job('Exporting styles as haldCLUTs', true, end_job)
+    local job = dt.gui.create_job(gettext.gettext('Exporting styles as haldCLUTs'), true, end_job)
     
     local size = 1
 
@@ -103,22 +105,22 @@ local function export_luts()
       io_lut:write_image(identity, output_path(style.name, job))
       count = count + 1
       job.percent = count / size
-      dt.print("Exported: " .. output_path(style.name, job))
+      dt.print(gettext.gettext("Exported: ") .. output_path(style.name, job))
     end
-    dt.print("Done exporting haldCLUTs")
+    dt.print(gettext.gettext("Done exporting haldCLUTs"))
     job.valid = false
     identity:reset()
   end
 end
 
 local export_button = dt.new_widget("button"){
-  label = "export",
+  label = gettext.gettext("export"),
   clicked_callback = export_luts
 }
 
 dt.register_lib(
-  "export haldclut",
-  "export haldclut",
+  gettext.gettext("export haldclut"),
+  gettext.gettext("export haldclut"),
   true,
   false,
   {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 100}},


### PR DESCRIPTION
This script creates a lighttable module which exports all user styles in the database as haldcluts. 

**Usage**
- Select the identity haldCLUT.
- Select a folder to output the generated haldCLUTs to
- Press export
- This will generate haldCLUTs for all user styles currently in the database.

Unfortunately due to limitations within the lua API I was unable to find a way to verify the a generated haldCLUTs is valid. Currently the script has only been tested on Linux (Ubuntu) but I would expect it to work on all OSs.