### PR TITLE
Make script manager scrollable.

### DIFF
--- a/tools/script_manager.lua
+++ b/tools/script_manager.lua
@@ -747,7 +747,7 @@ dt.register_lib(
   "script manager",     -- Visible name
   true,                -- expandable
   false,               -- resetable
-  {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_LEFT_BOTTOM", 100}},   -- containers
+  {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_LEFT_CENTER", 0}},   -- containers
   dt.new_widget("box") -- widget
   {
     orientation = "vertical",


### PR DESCRIPTION
Changed position of script manager to the center section of the left panel at the bottom of the section.  This takes care of the problem of darktable exceeding the vertical screen size and not being
scrollable.