### PR TITLE
New option: use links instead of multiple windows

### DIFF
--- a/contrib/german_umlauts.lua
+++ b/contrib/german_umlauts.lua
@@ -1,0 +1,23 @@
+--[[
+german_umlauts script for darktable
+]]
+
+--[[About this plugin
+This plugin adds the module "german_umlauts" to darktable's lighttable view.
+]]
+
+local dt = require "darktable"
+local gettext = dt.gettext
+
+gettext.bindtextdomain("german_umlauts",dt.configuration.config_dir.."/lua/locale/")
+
+local function _(msgid)
+    return gettext.dgettext("german_umlauts", msgid)
+end
+
+-- GUI --
+dt.gui.libs.image.register_action(
+  _("German Umlauts"),
+  function() dt.print(_("Sentence with German umlauts")) end,
+  _("Print a sentence with German umlauts")
+  )

--- a/locale/de_DE/LC_MESSAGES/german_umlauts.po
+++ b/locale/de_DE/LC_MESSAGES/german_umlauts.po
@@ -1,0 +1,30 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-04-27 14:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: de_DE\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: german_umlauts.lua:20
+msgid "German Umlauts"
+msgstr "Ae-Ä ae-ä Oe-Ö oe-ö Ue-Ü ueö ss-ß"
+
+#: german_umlauts.lua:21
+msgid "Sentence with German umlauts"
+msgstr "Übler Ärger auf den Hühnerhöfen: draußen fehlen wärmere Öfen."
+
+#: german_umlauts.lua:22
+msgid "Print a sentence with German umlauts"
+msgstr "Gibt einen Satz mit den deutschen Umlauten Ae-Ä ae-ä Oe-Ö oe-ö Ue-Ü ueö und ss-ß aus"


### PR DESCRIPTION
Well, there is the bug in macOS Mojave and Catalina (as I consider it as a bug) with the terminal command "open -Rn …". This -n option should induce the Finder to open one window for each file name, but it doesn't. It shows the contents of the directory in question instead, highlighting only the last file name selected. I filed the issue to Apple, but I don't believe that there will be a remedy in due time.

So I thought of a different approach. Instead of one window for each there could be one link for each, in an arbitrary directory.

I realized this as an option originally meant for Mac users. But maybe some Linux users may also prefer using this option to opening multiple windows when many images are selected. For Windows users there is the drawback that Windows seems to allow to set links in the terminal only to administrators. If there is no workaround for this restriction, I can shut out Windows from this option altogether.

Please give it a critical judgment and feel free to improve my English message wording.

@BzKevin Incorporating this option needed a massive reorganization of the code. Please be most critical as you are the owner of the script.