### PR TITLE
Bug Fix: script_manager can't process paths with lua special characters

### DIFF
--- a/lib/dtutils/string.lua
+++ b/lib/dtutils/string.lua
@@ -269,5 +269,31 @@ function dtutils_string.sanitize(str)
   end
 end
 
+dtutils_string.libdoc.functions["sanitize_lua"] = {
+  Name = [[sanitize_lua]],
+  Synopsis = [[escape lua 'magic' characters from a pattern string]],
+  Usage = [[local ds = require "lib/dtutils.string"
+
+    local result = ds.sanitize_lua(str)
+      str - string - the string that needs to be made safe]],
+  Description = [[sanitize_lua escapes lua 'magic' characters so that
+    a string may  be used in lua string/patten matching.]],
+  Return_Value = [[result - string - a lua pattern safe string]],
+  Limitations = [[]],
+  Example = [[]],
+  See_Also = [[]],
+  Reference = [[]],
+  License = [[]],
+  Copyright = [[]],
+}
+
+function dtutils_string.sanitize_lua(str)
+  str = string.gsub(str, "%-", "%%-")
+  str = string.gsub(str, "%(", "%%(")
+  str = string.gsub(str, "%)", "%%)")
+  return str
+end
+
+
 
 return dtutils_string

--- a/tools/script_manager.lua
+++ b/tools/script_manager.lua
@@ -39,6 +39,7 @@
 local dt = require "darktable"
 local du = require "lib/dtutils"
 local df = require "lib/dtutils.file"
+local ds = require "lib/dtutils.string"
 local dtsys = require "lib/dtutils.system"
 
 local gettext = dt.gettext
@@ -215,7 +216,7 @@ local function scan_scripts()
   -- scan the scripts
   local output = io.popen(find_cmd)
   for line in output:lines() do
-    local l = string.gsub(line, LUA_DIR .. PS, "") -- strip the lua dir off
+    local l = string.gsub(line, ds.sanitize_lua(LUA_DIR) .. PS, "") -- strip the lua dir off
     local script_file = l:sub(1,-5)
     if not string.match(script_file, "script_manager") then  -- let's not include ourself
       if not string.match(script_file, "plugins") then         -- skip plugins


### PR DESCRIPTION
Added a sanitize_lua function to the string library for sanitizing strings of lua "magic" characters before using the string in a string function that involves matching.

script_manager needs the path to the lua directory sanitized of lua
"magic" characters to prevent failure to extract the category and script
names.  Used the string library sanitize_lua function for that.