### PR TITLE
Fix OpenInExplorer shortcut function call

### DIFF
--- a/contrib/OpenInExplorer.lua
+++ b/contrib/OpenInExplorer.lua
@@ -209,7 +209,7 @@ end
 
 dt.register_event(
     "shortcut",
-    function(event, shortcut) open_in_fmanager(act_os, fmng_cmd[act_os]) end,
+    function(event, shortcut) open_in_fmanager() end,
     "OpenInExplorer"
 )  
 


### PR DESCRIPTION
Removed arguments from shortcut function call.  Removed DOS line endings.