### PR TITLE
executable_manager provide feedback

### DIFF
--- a/tools/executable_manager.lua
+++ b/tools/executable_manager.lua
@@ -118,7 +118,7 @@ end
 
 local executable_path_widgets = {}
 local executable_path_values = {}
-local placeholder_text = dt.configuration.running_os == windows and "select an executable" or "search path for executable"
+local placeholder_text = dt.configuration.running_os == windows and _("select an executable") or _("search path for executable")
 
 for i,exec in ipairs(exec_table) do 
   executable_path_values[exec] = dt.new_widget("entry"){
@@ -163,11 +163,11 @@ exec_man.selector = dt.new_widget("combobox"){
 
 for i,exec in ipairs(exec_table) do
   exec_man.stack[i] = dt.new_widget("box"){
-    dt.new_widget("section_label"){label = "current"},
+    dt.new_widget("section_label"){label = _("current")},
     executable_path_values[exec],
-    dt.new_widget("section_label"){label = "select"},
+    dt.new_widget("section_label"){label = _("select")},
     executable_path_widgets[exec],
-    dt.new_widget("section_label"){label = "reset"},
+    dt.new_widget("section_label"){label = _("reset")},
     dt.new_widget("button"){
       label = "clear",
       tooltip = _("Clear path for ") .. exec,

--- a/tools/executable_manager.lua
+++ b/tools/executable_manager.lua
@@ -117,8 +117,15 @@ for _,pref  in ipairs(matches) do
 end
 
 local executable_path_widgets = {}
+local executable_path_values = {}
+local placeholder_text = dt.configuration.running_os == windows and "select an executable" or "search path for executable"
 
 for i,exec in ipairs(exec_table) do 
+  executable_path_values[exec] = dt.new_widget("entry"){
+    text = df.get_executable_path_preference(exec),
+    placeholder = placeholder_text,
+    editable = false
+  }
   executable_path_widgets[exec] = dt.new_widget("file_chooser_button"){
     title = _("select ") .. exec .. _(" executable"),
     value = df.get_executable_path_preference(exec),
@@ -126,6 +133,7 @@ for i,exec in ipairs(exec_table) do
     changed_callback = function(self)
       if df.check_if_bin_exists(self.value) then
         df.set_executable_path_preference(exec, self.value)
+        executable_path_values[exec].text = df.get_executable_path_preference(exec)
       end
     end
   }
@@ -155,13 +163,18 @@ exec_man.selector = dt.new_widget("combobox"){
 
 for i,exec in ipairs(exec_table) do
   exec_man.stack[i] = dt.new_widget("box"){
+    dt.new_widget("section_label"){label = "current"},
+    executable_path_values[exec],
+    dt.new_widget("section_label"){label = "select"},
     executable_path_widgets[exec],
+    dt.new_widget("section_label"){label = "reset"},
     dt.new_widget("button"){
       label = "clear",
       tooltip = _("Clear path for ") .. exec,
       clicked_callback = function()
         df.set_executable_path_preference(exec, "")
         executable_path_widgets[exec].value = ""
+        executable_path_values[exec].text = ""
       end
     }
 


### PR DESCRIPTION
Added entry widget to display the current setting, or a placeholder specifying what would or should happen depending on operating system to provide visual feedback.

This change provides visual feedback when the value is set and when it is cleared.