### PR TITLE
278 fix register lib hang

### DIFF
--- a/contrib/AutoGrouper.lua
+++ b/contrib/AutoGrouper.lua
@@ -45,6 +45,17 @@ local function _(msgid)
     return gettext.dgettext("AutoGrouper", msgid)
 end
 
+local Ag = {}
+Ag.module_installed = false
+Ag.event_registered = false
+
+local GUI = {
+    gap =           {},
+    selected =      {},
+    collection =    {}
+}
+
+
 local function InRange(test, low, high) --tests if test value is within range of low and high (inclusive)
     if test >= low and test <= high then
         return true
@@ -111,12 +122,26 @@ local function main(on_collection)
     end
 end
 
+local function install_module()
+  if not Ag.module_installed then
+    dt.register_lib(
+        'AutoGroup_Lib',    -- Module name
+        _('auto group'),    -- name
+        true,   -- expandable
+        true,   -- resetable
+        {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 99}},   -- containers
+        dt.new_widget("box"){
+            orientation = "vertical",
+            GUI.gap,
+            GUI.selected,
+            GUI.collection
+            }
+    )
+    Ag.module_installed = true
+  end
+end
+
 -- GUI --
-GUI = {
-    gap =           {},
-    selected =      {},
-    collection =    {}
-}
 temp = dt.preferences.read(MOD, 'active_gap', 'integer')
 if not InRange(temp, 1, 86400) then temp = 3 end
 GUI.gap = dt.new_widget('slider'){
@@ -143,16 +168,20 @@ GUI.collection = dt.new_widget("button"){
     tooltip =_('auto group the entire collection'),
     clicked_callback = function() main(true) end
 }
-dt.register_lib(
-    'AutoGroup_Lib',    -- Module name
-    _('auto group'),    -- name
-    true,   -- expandable
-    true,   -- resetable
-    {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 99}},   -- containers
-    dt.new_widget("box"){
-        orientation = "vertical",
-        GUI.gap,
-        GUI.selected,
-        GUI.collection
-        }
-)
+
+if dt.gui.current_view().name == "lighttable" then
+  install_module()
+else
+  if not Ag.event_registered then
+    dt.register_event(
+      "view-changed",
+      function(event, old_view, new_view)
+        if new_view.name == "lighttable" and old_view.name == "darkroom" then
+          install_module()
+         end
+      end
+    )
+    Ag.event_registered = true
+  end
+end
+

--- a/contrib/HDRMerge.lua
+++ b/contrib/HDRMerge.lua
@@ -94,6 +94,10 @@ local GUI = { --GUI Elements Table
     }
 }
 
+HDRM.module_installed = false
+HDRM.event_registered = false
+
+
 --Detect User Styles--
 local styles = dt.styles
 local styles_count = 1 -- 'none' = 1
@@ -264,6 +268,23 @@ local function main()
 
 end
 
+local function install_module()
+  if not HDRM.module_installed then
+    dt.register_lib( -- register HDRMerge module
+        'HDRMerge_Lib', -- Module name
+        _('HDRMerge'), -- name
+        true,   -- expandable
+        true,   -- resetable
+        {[dt.gui.views.lighttable] = {'DT_UI_CONTAINER_PANEL_RIGHT_CENTER', 99}},   -- containers
+        dt.new_widget('box'){
+            orientation = 'vertical',
+            GUI.stack
+        }
+    )
+    HDRM.module_installed = true
+  end
+end
+
 -- GUI Elements --
 local lbl_hdr = dt.new_widget('section_label'){
     label = _('HDRMerge options')
@@ -411,14 +432,18 @@ else
     GUI.stack.active = 2
 end
 
-dt.register_lib( -- register HDRMerge module
-    'HDRMerge_Lib', -- Module name
-    _('HDRMerge'), -- name
-    true,   -- expandable
-    true,   -- resetable
-    {[dt.gui.views.lighttable] = {'DT_UI_CONTAINER_PANEL_RIGHT_CENTER', 99}},   -- containers
-    dt.new_widget('box'){
-        orientation = 'vertical',
-        GUI.stack
-        }
-)
+if dt.gui.current_view().name == "lighttable" then
+  install_module()
+else
+  if not HDRM.event_registered then
+    dt.register_event(
+      "view-changed",
+      function(event, old_view, new_view)
+        if new_view.name == "lighttable" and old_view.name == "darkroom" then
+          install_module()
+         end
+      end
+    )
+    HDRM.event_registered = true
+  end
+end

--- a/contrib/LabelsToTags.lua
+++ b/contrib/LabelsToTags.lua
@@ -55,6 +55,10 @@ du.check_min_api_version("3.0.0", "LabelsToTags")
 -- Lua 5.3 no longer has "unpack" but "table.unpack"
 unpack = unpack or table.unpack
 
+local ltt = {}
+ltt.module_installed = false
+ltt.event_registered = false
+
 local LIB_ID = "LabelsToTags"
 
 -- Helper functions: BEGIN
@@ -184,7 +188,7 @@ local function doTagging(selfC)
    job.valid = false
 end
 
-local my_widget = darktable.new_widget("box") {
+ltt.my_widget = darktable.new_widget("box") {
    orientation = "vertical",
    mappingComboBox,
    darktable.new_widget("button") {
@@ -217,6 +221,15 @@ darktable.register_tag_mapping = function(name, mapping)
    mappingComboBox.reset_callback(mappingComboBox)
 end
 
+local function install_module()
+  if not ltt.module_installed then
+   darktable.register_lib(LIB_ID,"labels to tags",true,true,{
+              [darktable.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER",20},
+                            },ltt.my_widget,nil,nil)
+    ltt.module_installed = true
+  end
+end
+
 --[[
 darktable.register_tag_mapping("Example",
 			       { ["+----*"] = { "Red", "Only red" },
@@ -229,6 +242,19 @@ darktable.register_tag_mapping("Example",
 				 ["*****R"] = { "Rejected" } })
 ]]
 
-darktable.register_lib(LIB_ID,"labels to tags",true,true,{
-			  [darktable.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER",20},
-								 },my_widget,nil,nil)
+if darktable.gui.current_view().name == "lighttable" then
+  install_module()
+else
+  if not ltt.event_registered then
+    darktable.register_event(
+      "view-changed",
+      function(event, old_view, new_view)
+        if new_view.name == "lighttable" and old_view.name == "darkroom" then
+          install_module()
+         end
+      end
+    )
+    ltt.event_registered = true
+  end
+end
+

--- a/contrib/copy_attach_detach_tags.lua
+++ b/contrib/copy_attach_detach_tags.lua
@@ -51,6 +51,11 @@ local function _(msgid)
     return gettext.dgettext("copy_attach_detach_tags", msgid)
 end
 
+local cadt = {}
+cadt.module_installed = false
+cadt.event_registered = false
+cadt.widget_table = {}
+
 
 local image_tags = {}
 
@@ -156,6 +161,26 @@ local function replace_tags()
   dt.print(_('Tags replaced'))
 end
 
+local function install_module()
+  if not cadt.module_installed then
+    dt.register_lib("tagging_addon","Tagging addon",true,true,{
+        [dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER",500}
+        },
+        dt.new_widget("box") {
+      --    orientation = "vertical",
+          reset_callback = function()
+                        taglist_label.label = ""
+                        image_tags = {}
+                        end,
+          table.unpack(cadt.widget_table),
+          },
+       nil,
+       nil
+      )
+    cadt.module_installed = true
+  end
+end
+
 -- create modul Tagging addons
 taglist_label.reset_callback = mcopy_tags
 
@@ -190,31 +215,31 @@ local box2 = dt.new_widget("box"){
 local sep = dt.new_widget("separator"){}
 
 -- pack elements into widget table for a nicer layout
-local widget_table = {}
 
-widget_table[1] = box1
-widget_table[#widget_table+1] = box2
+cadt.widget_table[1] = box1
+cadt.widget_table[#cadt.widget_table+1] = box2
 
-widget_table[#widget_table+1] = sep
-widget_table[#widget_table+1] = taglabel
-widget_table[#widget_table+1] = taglist_label
+cadt.widget_table[#cadt.widget_table+1] = sep
+cadt.widget_table[#cadt.widget_table+1] = taglabel
+cadt.widget_table[#cadt.widget_table+1] = taglist_label
 
 
 -- create modul
-dt.register_lib("tagging_addon","Tagging addon",true,true,{
-    [dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER",500}
-    },
-    dt.new_widget("box") {
-  --    orientation = "vertical",
-      reset_callback = function()
-                    taglist_label.label = ""
-                    image_tags = {}
-                    end,
-      table.unpack(widget_table),
-      },
-   nil,
-   nil
-  )
+if dt.gui.current_view().name == "lighttable" then
+  install_module()
+else
+  if not cadt.event_registered then
+    dt.register_event(
+      "view-changed",
+      function(event, old_view, new_view)
+        if new_view.name == "lighttable" and old_view.name == "darkroom" then
+          install_module()
+         end
+      end
+    )
+    cadt.event_registered = true
+  end
+end
 
 
 -- shortcut for copy

--- a/contrib/geoToolbox.lua
+++ b/contrib/geoToolbox.lua
@@ -40,6 +40,12 @@ local function _(msgid)
     return gettext.dgettext("geoToolbox", msgid)
 end
 
+
+local gT = {}
+gT.module_installed = false
+gT.event_registered = false
+
+
 -- <GUI>
 local labelDistance = dt.new_widget("label")
 labelDistance.label = _("Distance:")
@@ -572,6 +578,22 @@ local function altitude_profile()
 
 end
 
+local function install_module()
+  if not gT.module_installed then
+    dt.register_lib(
+      "geoToolbox",        -- Module name
+      "geo toolbox",       -- name
+      true,                -- expandable
+      false,               -- resetable
+      {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 100}},   -- containers
+      gT.widget,
+      nil,-- view_enter
+      nil -- view_leave
+    )
+    gT.module_installed = true
+  end
+end
+
 
 local separator = dt.new_widget("separator"){}
 local separator2 = dt.new_widget("separator"){}
@@ -579,13 +601,7 @@ local separator3 = dt.new_widget("separator"){}
 local separator4 = dt.new_widget("separator"){}
 local separator5 = dt.new_widget("separator"){}
 
-dt.register_lib(
-  "geoToolbox",        -- Module name
-  "geo toolbox",       -- name
-  true,                -- expandable
-  false,               -- resetable
-  {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 100}},   -- containers
-  dt.new_widget("box")
+gT.widget = dt.new_widget("box")
   {
     orientation = "vertical",
     dt.new_widget("button")
@@ -664,10 +680,24 @@ dt.register_lib(
       clicked_callback = altitude_profile
     },
     labelDistance
-  },
-  nil,-- view_enter
-  nil -- view_leave
-)
+  }
+
+
+if dt.gui.current_view().name == "lighttable" then
+  install_module()
+else
+  if not gT.event_registered then
+    dt.register_event(
+      "view-changed",
+      function(event, old_view, new_view)
+        if new_view.name == "lighttable" and old_view.name == "darkroom" then
+          install_module()
+         end
+      end
+    )
+    gT.event_registered = true
+  end
+end
 
 -- Preferences
 dt.preferences.register("geoToolbox",

--- a/contrib/gpx_export.lua
+++ b/contrib/gpx_export.lua
@@ -36,6 +36,10 @@ local function _(msgid)
   return gettext.dgettext("gpx_export", msgid)
 end
 
+local gpx = {}
+gpx.module_installed = false
+gpx.event_registered = false
+
 local path_entry = dt.new_widget("entry")
 {
   text = dt.preferences.read("gpx_exporter", "gpxExportPath", "string"),
@@ -127,31 +131,55 @@ local function create_gpx_file()
   end
 end
 
-dt.register_lib(
-  "gpx_exporter",
-  "gpx export",
-  true, -- expandable
-  true, -- resetable
-  {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 100}},   -- containers
+local function install_module()
+  if not gpx.module_installed then
+    dt.register_lib(
+      "gpx_exporter",
+      "gpx export",
+      true, -- expandable
+      true, -- resetable
+      {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 100}},   -- containers
+      gpx.widget,
+      nil,-- view_enter
+      nil -- view_leave
+    )
+    gpx.module_installed = true
+  end
+end
+
+gpx.widget = dt.new_widget("box")
+{
+  orientation = "vertical",
+  dt.new_widget("button")
+  {
+    label = _("export"),
+    tooltip = _("export gpx file"),
+    clicked_callback = create_gpx_file
+  },
   dt.new_widget("box")
   {
-    orientation = "vertical",
-    dt.new_widget("button")
+    orientation = "horizontal",
+    dt.new_widget("label")
     {
-      label = _("export"),
-      tooltip = _("export gpx file"),
-      clicked_callback = create_gpx_file
+      label = _("file:"),
     },
-    dt.new_widget("box")
-    {
-      orientation = "horizontal",
-      dt.new_widget("label")
-      {
-        label = _("file:"),
-      },
-      path_entry
-    },
+    path_entry
   },
-  nil,-- view_enter
-  nil -- view_leave
-)
+}
+
+
+if dt.gui.current_view().name == "lighttable" then
+  install_module()
+else
+  if not gpx.event_registered then
+    dt.register_event(
+      "view-changed",
+      function(event, old_view, new_view)
+        if new_view.name == "lighttable" and old_view.name == "darkroom" then
+          install_module()
+         end
+      end
+    )
+    gpx.event_registered = true
+  end
+end

--- a/contrib/image_time.lua
+++ b/contrib/image_time.lua
@@ -110,6 +110,8 @@ local ds = require "lib/dtutils.string"
 local gettext = dt.gettext
 
 local img_time = {}
+img_time.module_installed = false
+img_time.event_registered = false
 
 du.check_min_api_version("3.0.0", "image_time") 
 
@@ -390,6 +392,22 @@ local function reset_widgets()
   img_time.adir.selected = 1
 end
 
+local function install_module()
+  if not img_time.module_installed then
+    dt.register_lib(
+      "image_time",     -- Module name
+      _("image time"),     -- Visible name
+      true,                -- expandable
+      true,               -- resetable
+      {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 100}},   -- containers
+      img_time.widget,
+      nil,-- view_enter
+      nil -- view_leave
+    )
+    img_time.module_installed = true
+  end
+end
+
 -- widgets
 
 img_time.widgets  = {
@@ -528,13 +546,19 @@ img_time.widget = dt.new_widget("box"){
   img_time.stack,
 }
 
-dt.register_lib(
-  "image_time",     -- Module name
-  _("image time"),     -- Visible name
-  true,                -- expandable
-  true,               -- resetable
-  {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 100}},   -- containers
-  img_time.widget,
-  nil,-- view_enter
-  nil -- view_leave
-)
+if dt.gui.current_view().name == "lighttable" then
+  install_module()
+else
+  if not img_time.event_registered then
+    dt.register_event(
+      "view-changed",
+      function(event, old_view, new_view)
+        if new_view.name == "lighttable" and old_view.name == "darkroom" then
+          install_module()
+         end
+      end
+    )
+    img_time.event_registered = true
+  end
+end
+

--- a/contrib/rename-tags.lua
+++ b/contrib/rename-tags.lua
@@ -35,6 +35,10 @@ local debug = require "darktable.debug"
 -- check API version
 du.check_min_api_version("3.0.0", "rename-tags") 
 
+local rt = {}
+rt.module_installed = false
+rt.event_registered = false
+
 -- GUI entries
 local old_tag = darktable.new_widget("entry") { tooltip = "Enter old tag" }
 local new_tag = darktable.new_widget("entry") { tooltip = "Enter new tag" }
@@ -99,6 +103,13 @@ local function rename_tags()
   rename_reset()
 end
 
+local function install_module()
+  if not rt.module_installed then
+    darktable.register_lib ("rename_tags", "rename tag", true, true, {[darktable.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 20},}, rt.rename_widget, nil, nil)
+    rt.module_installed = true
+  end
+end
+
 -- GUI
 local old_widget = darktable.new_widget ("box") {
     orientation = "horizontal",
@@ -112,7 +123,7 @@ local new_widget = darktable.new_widget ("box") {
     new_tag
 }
 
-local rename_widget = darktable.new_widget ("box") {
+rt.rename_widget = darktable.new_widget ("box") {
     orientation = "vertical",
     reset_callback = rename_reset,
     old_widget,
@@ -120,6 +131,20 @@ local rename_widget = darktable.new_widget ("box") {
     darktable.new_widget("button") { label = "Go", clicked_callback = rename_tags }
 }
 
+if darktable.gui.current_view().name == "lighttable" then
+  install_module()
+else
+  if not rt.event_registered then
+    darktable.register_event(
+      "view-changed",
+      function(event, old_view, new_view)
+        if new_view.name == "lighttable" and old_view.name == "darkroom" then
+          install_module()
+         end
+      end
+    )
+    rt.event_registered = true
+  end
+end
 
-darktable.register_lib ("rename_tags", "rename tag", true, true, {[darktable.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 20},}, rename_widget, nil, nil)
 

--- a/contrib/transfer_hierarchy.lua
+++ b/contrib/transfer_hierarchy.lua
@@ -99,6 +99,10 @@ end
 
 -- Helper functions: BEGIN
 
+local th = {}
+th.module_installed = false
+th.event_registered = false
+
 local function pathExists(path)
    local success, err, errno = os.rename(path, path)
    if not success then
@@ -120,6 +124,16 @@ local function createDirectory(path)
    else
       return nil
    end
+end
+
+local function install_module()
+  if not th.module_installed then
+    darktable.register_lib(LIB_ID,
+               "transfer hierarchy", true, true, {
+            [darktable.gui.views.lighttable] = { "DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 700 }
+               }, th.transfer_widget, nil, nil)
+    th.module_installed = true
+  end
 end
 
 -- Helper functions: END
@@ -292,7 +306,7 @@ end
 
 
 
-local transfer_widget = darktable.new_widget("box") {
+th.transfer_widget = darktable.new_widget("box") {
    orientation = "vertical",
    darktable.new_widget("button") {
      label = _("calculate"),
@@ -347,12 +361,18 @@ darktable.preferences.register(
 
 -- Preferences: END
 
-
-
-
-
-
-darktable.register_lib(LIB_ID,
-		       "transfer hierarchy", true, true, {
-			  [darktable.gui.views.lighttable] = { "DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 700 }
-		       }, transfer_widget, nil, nil)
+if darktable.gui.current_view().name == "lighttable" then
+  install_module()
+else
+  if not th.event_registered then
+    darktable.register_event(
+      "view-changed",
+      function(event, old_view, new_view)
+        if new_view.name == "lighttable" and old_view.name == "darkroom" then
+          install_module()
+         end
+      end
+    )
+    th.event_registered = true
+  end
+end

--- a/examples/moduleExample.lua
+++ b/examples/moduleExample.lua
@@ -46,6 +46,44 @@ local function _(msgid)
     return gettext.dgettext("moduleExample", msgid)
 end
 
+-- declare a local namespace and a couple of variables we'll need to install the module
+local mE = {}
+mE.widgets = {}
+mE.event_registered = false  -- keep track of whether we've added an event callback or not
+mE.module_installed = false  -- keep track of whether the module is module_installed
+
+--[[ We have to create the module in one of two ways depending on which view darktable starts
+     in.  In orker to not repeat code, we wrap the darktable.register_lib in a local function.
+  ]]
+
+local function install_module()
+  if not mE.module_installed then
+    -- https://www.darktable.org/lua-api/index.html#darktable_register_lib
+    dt.register_lib(
+      "exampleModule",     -- Module name
+      "exampleModule",     -- name
+      true,                -- expandable
+      false,               -- resetable
+      {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 100}},   -- containers
+      -- https://www.darktable.org/lua-api/types_lua_box.html
+      dt.new_widget("box") -- widget
+      {
+        orientation = "vertical",
+        dt.new_widget("button")
+        {
+          label = _("MyButton"),
+          clicked_callback = function (_)
+            dt.print(_("Button clicked"))
+          end
+        },
+        table.unpack(mE.widgets),
+      },
+      nil,-- view_enter
+      nil -- view_leave
+    )
+    mE.module_installed = true
+  end
+end
 
 -- https://www.darktable.org/lua-api/types_lua_check_button.html
 local check_button = dt.new_widget("check_button"){label = _("MyCheck_button"), value = true}
@@ -90,35 +128,35 @@ local slider = dt.new_widget("slider")
   value = 52          -- The current value of the slider
 }
 
--- https://www.darktable.org/lua-api/index.html#darktable_register_lib
-dt.register_lib(
-  "exampleModule",     -- Module name
-  "exampleModule",     -- name
-  true,                -- expandable
-  false,               -- resetable
-  {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 100}},   -- containers
-  -- https://www.darktable.org/lua-api/types_lua_box.html
-  dt.new_widget("box") -- widget
-  {
-    orientation = "vertical",
-    dt.new_widget("button")
-    {
-      label = _("MyButton"),
-      clicked_callback = function (_)
-        dt.print(_("Button clicked"))
+-- pack the widgets in a table for loading in the module
+
+table.insert(mE.widgets, check_button)
+table.insert(mE.widgets, combobox)
+table.insert(mE.widgets, entry)
+table.insert(mE.widgets, file_chooser_button)
+table.insert(mE.widgets, label)
+table.insert(mE.widgets, separator)
+table.insert(mE.widgets, slider)
+
+-- ... and tell dt about it all
+
+
+if dt.gui.current_view().name == "lighttable" then -- make sure we are in lighttable view
+  install_module()  -- register the lib
+else
+  if not mE.event_registered then -- if we are not in lighttable view then register an event to signal when we might be
+    -- https://www.darktable.org/lua-api/index.html#darktable_register_event
+    dt.register_event(
+      "view-changed",  -- we want to be informed when the view changes
+      function(event, old_view, new_view)
+        if new_view.name == "lighttable" and old_view.name == "darkroom" then  -- if the view changes from darkroom to lighttable
+          install_module()  -- register the lib
+         end
       end
-    },
-    check_button,
-    combobox,   
-    entry,
-    file_chooser_button,
-    label,
-    separator,
-    slider
-  },
-  nil,-- view_enter
-  nil -- view_leave
-)
+    )
+    mE.event_registered = true  --  keep track of whether we have an event handler installed
+  end
+end
 
 -- vim: shiftwidth=2 expandtab tabstop=2 cindent syntax=lua
 -- kate: hl Lua;

--- a/official/enfuse.lua
+++ b/official/enfuse.lua
@@ -46,10 +46,35 @@ du.check_min_api_version("3.0.0", "enfuse")
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("enfuse",dt.configuration.config_dir..PS .. "lua" .. PS .. "locale" .. PS)
 
+local enf = {}
+enf.event_registered = false
+enf.module_installed = false
+enf.lib_widgets = {}
+
 local function _(msgid)
     return gettext.dgettext("enfuse", msgid)
 end
 
+local function install_module()
+  if not enf.module_installed then
+    dt.register_lib(
+      "enfuse",                                                                    -- plugin name
+      "enfuse",                                                                    -- name
+      true,                                                                        -- expandable
+      false,                                                                       -- resetable
+      {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 100}},   -- containers
+      dt.new_widget("box")                                                         -- widget
+      {
+        orientation = "vertical",
+        sensitive = enfuse_installed,
+        table.unpack(enf.lib_widgets)
+      },
+      nil,-- view_enter
+      nil -- view_leave
+    )
+    enf.module_installed = true
+  end
+end
 -- add a new lib
 -- is enfuse installed?
 local enfuse_installed = df.check_if_bin_exists("enfuse")
@@ -229,30 +254,31 @@ if enfuse_installed then
   local lib_widgets = {}
 
   if not enfuse_installed then
-    table.insert(lib_widgets, df.executable_path_widget({"ffmpeg"}))
+    table.insert(enf.lib_widgets, df.executable_path_widget({"ffmpeg"}))
   end
-  table.insert(lib_widgets, exposure_mu)
-  table.insert(lib_widgets, depth)
-  table.insert(lib_widgets, blend_colorspace)
-  table.insert(lib_widgets, enfuse_button)
+  table.insert(enf.lib_widgets, exposure_mu)
+  table.insert(enf.lib_widgets, depth)
+  table.insert(enf.lib_widgets, blend_colorspace)
+  table.insert(enf.lib_widgets, enfuse_button)
 
    
   -- ... and tell dt about it all
-  dt.register_lib(
-    "enfuse",                                                                    -- plugin name
-    "enfuse",                                                                    -- name
-    true,                                                                        -- expandable
-    false,                                                                       -- resetable
-    {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 100}},   -- containers
-    dt.new_widget("box")                                                         -- widget
-    {
-      orientation = "vertical",
-      sensitive = enfuse_installed,
-      table.unpack(lib_widgets)
-    },
-    nil,-- view_enter
-    nil -- view_leave
-  )
+  if dt.gui.current_view().name == "lighttable" then
+    install_module()
+  else
+    if not enf.event_registered then
+      dt.register_event(
+        "view-changed",
+        function(event, old_view, new_view)
+          if new_view.name == "lighttable" and old_view.name == "darkroom" then
+            dt.print_log("view changed from darkroom to lighttable")
+            install_module()
+           end
+        end
+      )
+      enf.event_registered = true
+    end
+  end
 else
   dt.print_error("enfuse executable not found")
   error("enfuse executable not found")

--- a/official/enfuse.lua
+++ b/official/enfuse.lua
@@ -271,7 +271,6 @@ if enfuse_installed then
         "view-changed",
         function(event, old_view, new_view)
           if new_view.name == "lighttable" and old_view.name == "darkroom" then
-            dt.print_log("view changed from darkroom to lighttable")
             install_module()
            end
         end

--- a/official/image_path_in_ui.lua
+++ b/official/image_path_in_ui.lua
@@ -33,7 +33,21 @@ local du = require "lib/dtutils"
 
 du.check_min_api_version("2.0.0", "image_path_in_ui") 
 
+local ipiu = {}
+ipiu.module_installed = false
+ipiu.event_registered = false
+
 local main_label = dt.new_widget("label"){selectable = true, ellipsize = "middle", halign = "start"}
+
+local function install_module()
+  if not ipiu.module_installed then
+    dt.register_lib("image_path_no_ui","Selected Images path",true,false,{
+      [dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_LEFT_CENTER",300}
+      }, main_label
+    )
+    ipiu.module_installed = true
+  end
+end
 
 local function reset_widget()
   local selection = dt.gui.selection()
@@ -54,10 +68,21 @@ end
 
 main_label.reset_callback = reset_widget
 
-dt.register_lib("image_path_no_ui","Selected Images path",true,false,{
-    [dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_LEFT_CENTER",300}
-    }, main_label
-  );
+if dt.gui.current_view().name == "lighttable" then
+  install_module()
+else
+  if not ipiu.event_registered then
+    dt.register_event(
+      "view-changed",
+      function(event, old_view, new_view)
+        if new_view.name == "lighttable" and old_view.name == "darkroom" then
+          install_module()
+         end
+      end
+    )
+    ipiu.event_registered = true
+  end
+end
 
 dt.register_event("mouse-over-image-changed",reset_widget);
 

--- a/tools/script_manager.lua
+++ b/tools/script_manager.lua
@@ -450,6 +450,26 @@ local function link_downloads_directory()
   os.execute("ln -s " .. "$HOME/Downloads " .. LUA_DIR .. "/downloads")
 end
 
+local function install_module()
+  if not sm.module_installed then
+    dt.register_lib(
+      "script_manager",     -- Module name
+      "script manager",     -- Visible name
+      true,                -- expandable
+      false,               -- resetable
+      {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_LEFT_CENTER", 0}},   -- containers
+      dt.new_widget("box") -- widget
+      {
+        orientation = "vertical",
+        sm.main_box,
+      },
+      nil,-- view_enter
+      nil -- view_leave
+    )
+    sm.module_installed = true
+  end
+end
+
 -- - - - - - - - - - - - - - - - - - - - - - - - 
 -- M A I N  P R O G R A M
 -- - - - - - - - - - - - - - - - - - - - - - - - 
@@ -466,6 +486,8 @@ sm.script_names = {}
 sm.script_paths = {}
 sm.main_menu_choices = {}
 sm.main_stack_items = {}
+sm.event_registered = false
+sm.module_installed = false
 
 -- see if we've run this before
 
@@ -742,21 +764,21 @@ sm.main_box = dt.new_widget("box"){
 -- D A R K T A B L E  I N T E G R A T I O N 
 -- - - - - - - - - - - - - - - - - - - - - - - - 
 
--- register the module
-dt.register_lib(
-  "script_manager",     -- Module name
-  "script manager",     -- Visible name
-  true,                -- expandable
-  false,               -- resetable
-  {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_LEFT_CENTER", 0}},   -- containers
-  dt.new_widget("box") -- widget
-  {
-    orientation = "vertical",
-    sm.main_box,
-  },
-  nil,-- view_enter
-  nil -- view_leave
-)
+if dt.gui.current_view().name == "lighttable" then
+  install_module()
+else
+  if not sm.event_registered then
+    dt.register_event(
+      "view-changed",
+      function(event, old_view, new_view)
+        if new_view.name == "lighttable" and old_view.name == "darkroom" then
+          install_module()
+         end
+      end
+    )
+    sm.event_registered = true
+  end
+end
 
 -- set up the scripts block if we have them otherwise we'll wait until we download them
 


### PR DESCRIPTION
Added check to see if the current view was lighttable before calling darktable.register_lib.  If the view was not, then added an event listener to the view-changed event.  When the view changed to lighttable darktable.register_lib was called to install the module.

Fixes #278 