### PR TITLE
Fix script_manager not starting (and any other register_lib module)

### DIFF
--- a/contrib/AutoGrouper.lua
+++ b/contrib/AutoGrouper.lua
@@ -169,7 +169,7 @@ GUI.collection = dt.new_widget("button"){
     clicked_callback = function() main(true) end
 }
 
-if dt.gui.current_view().name == "lighttable" then
+if dt.gui.current_view().id == "lighttable" then
   install_module()
 else
   if not Ag.event_registered then

--- a/contrib/HDRMerge.lua
+++ b/contrib/HDRMerge.lua
@@ -432,7 +432,7 @@ else
     GUI.stack.active = 2
 end
 
-if dt.gui.current_view().name == "lighttable" then
+if dt.gui.current_view().id == "lighttable" then
   install_module()
 else
   if not HDRM.event_registered then

--- a/contrib/LabelsToTags.lua
+++ b/contrib/LabelsToTags.lua
@@ -242,7 +242,7 @@ darktable.register_tag_mapping("Example",
 				 ["*****R"] = { "Rejected" } })
 ]]
 
-if darktable.gui.current_view().name == "lighttable" then
+if darktable.gui.current_view().id == "lighttable" then
   install_module()
 else
   if not ltt.event_registered then

--- a/contrib/copy_attach_detach_tags.lua
+++ b/contrib/copy_attach_detach_tags.lua
@@ -225,7 +225,7 @@ cadt.widget_table[#cadt.widget_table+1] = taglist_label
 
 
 -- create modul
-if dt.gui.current_view().name == "lighttable" then
+if dt.gui.current_view().id == "lighttable" then
   install_module()
 else
   if not cadt.event_registered then

--- a/contrib/exportLUT.lua
+++ b/contrib/exportLUT.lua
@@ -156,7 +156,7 @@ table.insert(eL.widgets, export_chooser_button)
 table.insert(eL.widgets, warning_label)
 table.insert(eL.widgets, export_button)
 
-if dt.gui.current_view().name == "lighttable" then
+if dt.gui.current_view().id == "lighttable" then
   install_module()
 else
   if not eL.event_registered then

--- a/contrib/ext_editor.lua
+++ b/contrib/ext_editor.lua
@@ -411,7 +411,7 @@ table.insert(ee.widgets, combobox)
 table.insert(ee.widgets, box1)
 
 -- register new module "external editors" in lighttable ------------------------
-if dt.gui.current_view().name == "lighttable" then
+if dt.gui.current_view().id == "lighttable" then
   install_module()
 else
   if not ee.event_registered then

--- a/contrib/face_recognition.lua
+++ b/contrib/face_recognition.lua
@@ -484,7 +484,7 @@ fc.widget = dt.new_widget("box"){
   table.unpack(widgets),
 }
 
-if dt.gui.current_view().name == "lighttable" then
+if dt.gui.current_view().id == "lighttable" then
   install_module()
 else
   if not fc.event_registered then

--- a/contrib/geoToolbox.lua
+++ b/contrib/geoToolbox.lua
@@ -683,7 +683,7 @@ gT.widget = dt.new_widget("box")
   }
 
 
-if dt.gui.current_view().name == "lighttable" then
+if dt.gui.current_view().id == "lighttable" then
   install_module()
 else
   if not gT.event_registered then

--- a/contrib/gpx_export.lua
+++ b/contrib/gpx_export.lua
@@ -168,7 +168,7 @@ gpx.widget = dt.new_widget("box")
 }
 
 
-if dt.gui.current_view().name == "lighttable" then
+if dt.gui.current_view().id == "lighttable" then
   install_module()
 else
   if not gpx.event_registered then

--- a/contrib/image_time.lua
+++ b/contrib/image_time.lua
@@ -546,7 +546,7 @@ img_time.widget = dt.new_widget("box"){
   img_time.stack,
 }
 
-if dt.gui.current_view().name == "lighttable" then
+if dt.gui.current_view().id == "lighttable" then
   install_module()
 else
   if not img_time.event_registered then

--- a/contrib/photils.lua
+++ b/contrib/photils.lua
@@ -435,7 +435,7 @@ dt.preferences.register(MODULE_NAME,
 
 dt.register_event("mouse-over-image-changed",PHOTILS.image_changed)
 
-if dt.gui.current_view().name == "lighttable" then
+if dt.gui.current_view().id == "lighttable" then
   install_module()
 else
   if not PHOTILS.event_registered then

--- a/contrib/quicktag.lua
+++ b/contrib/quicktag.lua
@@ -251,7 +251,7 @@ qt.widget_table[#qt.widget_table  + 1] = new_qt_widget
 
 
 --create module
-if dt.gui.current_view().name == "lighttable" then
+if dt.gui.current_view().id == "lighttable" then
   install_module()
 else
   if not qt.event_registered then

--- a/contrib/rename-tags.lua
+++ b/contrib/rename-tags.lua
@@ -131,7 +131,7 @@ rt.rename_widget = darktable.new_widget ("box") {
     darktable.new_widget("button") { label = "Go", clicked_callback = rename_tags }
 }
 
-if darktable.gui.current_view().name == "lighttable" then
+if darktable.gui.current_view().id == "lighttable" then
   install_module()
 else
   if not rt.event_registered then

--- a/contrib/transfer_hierarchy.lua
+++ b/contrib/transfer_hierarchy.lua
@@ -361,7 +361,7 @@ darktable.preferences.register(
 
 -- Preferences: END
 
-if darktable.gui.current_view().name == "lighttable" then
+if darktable.gui.current_view().id == "lighttable" then
   install_module()
 else
   if not th.event_registered then

--- a/examples/moduleExample.lua
+++ b/examples/moduleExample.lua
@@ -141,7 +141,7 @@ table.insert(mE.widgets, slider)
 -- ... and tell dt about it all
 
 
-if dt.gui.current_view().name == "lighttable" then -- make sure we are in lighttable view
+if dt.gui.current_view().id == "lighttable" then -- make sure we are in lighttable view
   install_module()  -- register the lib
 else
   if not mE.event_registered then -- if we are not in lighttable view then register an event to signal when we might be

--- a/official/enfuse.lua
+++ b/official/enfuse.lua
@@ -263,7 +263,7 @@ if enfuse_installed then
 
    
   -- ... and tell dt about it all
-  if dt.gui.current_view().name == "lighttable" then
+  if dt.gui.current_view().id == "lighttable" then
     install_module()
   else
     if not enf.event_registered then

--- a/official/image_path_in_ui.lua
+++ b/official/image_path_in_ui.lua
@@ -68,7 +68,7 @@ end
 
 main_label.reset_callback = reset_widget
 
-if dt.gui.current_view().name == "lighttable" then
+if dt.gui.current_view().id == "lighttable" then
   install_module()
 else
   if not ipiu.event_registered then

--- a/tools/executable_manager.lua
+++ b/tools/executable_manager.lua
@@ -209,7 +209,7 @@ update_combobox_choices(exec_man.selector, exec_table, 1)
 -- register the lib
 
 
-if dt.gui.current_view().name == "lighttable" then
+if dt.gui.current_view().id == "lighttable" then
   install_module()
 else
   if not exec_man.event_registered then

--- a/tools/script_manager.lua
+++ b/tools/script_manager.lua
@@ -764,7 +764,7 @@ sm.main_box = dt.new_widget("box"){
 -- D A R K T A B L E  I N T E G R A T I O N 
 -- - - - - - - - - - - - - - - - - - - - - - - - 
 
-if dt.gui.current_view().name == "lighttable" then
+if dt.gui.current_view().id == "lighttable" then
   install_module()
 else
   if not sm.event_registered then


### PR DESCRIPTION
changed darktable.current_view().name to darktable.current_view().id for view check because name is translated and id is not.