### PR TITLE
Added compatibility for lua events API change 6.2.1.

### DIFF
--- a/contrib/AutoGrouper.lua
+++ b/contrib/AutoGrouper.lua
@@ -40,6 +40,7 @@ local dt = require "darktable"
 local MOD = 'autogrouper'
 local gettext = dt.gettext
 -- Tell gettext where to find the .mo file translating messages for a particular domain
+local CURR_API_STRING = dt.configuration_api_version_string
 gettext.bindtextdomain("AutoGrouper",dt.configuration.config_dir.."/lua/locale/")
 local function _(msgid)
     return gettext.dgettext("AutoGrouper", msgid)
@@ -174,7 +175,7 @@ if dt.gui.current_view().id == "lighttable" then
 else
   if not Ag.event_registered then
     dt.register_event(
-      "view-changed",
+      CURR_API_STRING >= "6.2.1" and "AutoGrouper", "view-changed" or "view-changed" ,
       function(event, old_view, new_view)
         if new_view.name == "lighttable" and old_view.name == "darkroom" then
           install_module()

--- a/contrib/HDRMerge.lua
+++ b/contrib/HDRMerge.lua
@@ -50,6 +50,7 @@ local dsys = require 'lib/dtutils.system'
 local mod = 'module_HDRMerge'
 local os_path_seperator = '/'
 if dt.configuration.running_os == 'windows' then os_path_seperator = '\\' end
+local CURR_API_STRING = dt.configuration.api_version_string
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 local gettext = dt.gettext
@@ -437,7 +438,7 @@ if dt.gui.current_view().id == "lighttable" then
 else
   if not HDRM.event_registered then
     dt.register_event(
-      "view-changed",
+      CURR_API_STRING >= "6.2.1" and "HDRmerge", "view-changed" or "view-changed" ,
       function(event, old_view, new_view)
         if new_view.name == "lighttable" and old_view.name == "darkroom" then
           install_module()

--- a/contrib/LabelsToTags.lua
+++ b/contrib/LabelsToTags.lua
@@ -60,6 +60,7 @@ ltt.module_installed = false
 ltt.event_registered = false
 
 local LIB_ID = "LabelsToTags"
+local CURR_API_STRING = darktable.configuration.api_version_string
 
 -- Helper functions: BEGIN
 
@@ -247,7 +248,7 @@ if darktable.gui.current_view().id == "lighttable" then
 else
   if not ltt.event_registered then
     darktable.register_event(
-      "view-changed",
+      CURR_API_STRING >= "6.2.1" and LIB_ID, "view-changed" or "view-changed" ,
       function(event, old_view, new_view)
         if new_view.name == "lighttable" and old_view.name == "darkroom" then
           install_module()

--- a/contrib/OpenInExplorer.lua
+++ b/contrib/OpenInExplorer.lua
@@ -65,6 +65,7 @@ end
 
 local act_os = dt.configuration.running_os
 local PS = act_os == "windows" and  "\\"  or  "/"
+local CURR_API_STRING = dt.configuration.api_version_string
 
 --Detect OS and quit if it is not supported.	
 if act_os ~= "macos" and act_os ~= "windows" and act_os ~= "linux" then
@@ -208,7 +209,7 @@ if act_os ~= "windows" then
 end
 
 dt.register_event(
-    "shortcut",
+    CURR_API_STRING >= "6.2.1" and "OpenInExplorer", "shortcut" or "shortcut",
     function(event, shortcut) open_in_fmanager() end,
     "OpenInExplorer"
 )  

--- a/contrib/autostyle.lua
+++ b/contrib/autostyle.lua
@@ -42,6 +42,7 @@ local filelib = require "lib/dtutils.file"
 
 -- Forward declare the functions
 local autostyle_apply_one_image,autostyle_apply_one_image_event,autostyle_apply,exiftool_attribute,capture
+local CURR_API_STRING = darktable.configuration.api_version_string
 
 -- Tested it with darktable 1.6.1 and darktable git from 2014-01-25
 du.check_min_api_version("2.0.2", "autostyle") 
@@ -151,11 +152,12 @@ function get_stdout(cmd)
 end
 
 -- Registering events
-darktable.register_event("shortcut",autostyle_apply,
+darktable.register_event(CURR_API_STRING >= "6.2.1" and "autostyle", "shortcut" or "shortcut" ,autostyle_apply,
        "Apply your chosen style from exiftool tags")
 
 darktable.preferences.register("autostyle","exif_tag","string","Autostyle: EXIF_tag=value=>style","apply a style automatically if an EXIF_tag matches value. Find the tag with exiftool","")
 
-darktable.register_event("post-import-image",autostyle_apply_one_image_event)
+darktable.register_event(CURR_API_STRING >= "6.2.1" and "autostyle", "post-import-image" or "post-import-image" ,
+  autostyle_apply_one_image_event)
 
 

--- a/contrib/clear_GPS.lua
+++ b/contrib/clear_GPS.lua
@@ -44,6 +44,7 @@ local gettext = dt.gettext
 local NaN = 0/0
 
 du.check_min_api_version("3.0.0", "clear_GPS") 
+local CURR_API_STRING = dt.configuration.api_version_string
 
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
@@ -70,7 +71,7 @@ dt.gui.libs.image.register_action(
 )
 
 dt.register_event(
-  "shortcut",
+  CURR_API_STRING >= "6.2.1" and "clearGPS", "shortcut" or "shortcut" ,
   function(event, shortcut) clear_GPS(dt.gui.action_images) end,
   _("Clear GPS data")
 )

--- a/contrib/copy_attach_detach_tags.lua
+++ b/contrib/copy_attach_detach_tags.lua
@@ -43,6 +43,7 @@ local debug = require "darktable.debug"
 local gettext = dt.gettext
 
 du.check_min_api_version("3.0.0", "copy_attach_detach_tags") 
+local CURR_API_STRING = dt.configuration.api_version_string
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("copy_attach_detach_tags",dt.configuration.config_dir.."/lua/locale/")
@@ -233,7 +234,7 @@ if dt.gui.current_view().id == "lighttable" then
 else
   if not cadt.event_registered then
     dt.register_event(
-      "view-changed",
+      CURR_API_STRING >= "6.2.1" and "cadt", "view-changed" or "view-changed" ,
       function(event, old_view, new_view)
         if new_view.name == "lighttable" and old_view.name == "darkroom" then
           install_module()
@@ -246,22 +247,22 @@ end
 
 
 -- shortcut for copy
-dt.register_event("shortcut",
+dt.register_event(CURR_API_STRING >= "6.2.1" and "cadt_ct", "shortcut" or "shortcut" ,
                    mcopy_tags,
                    _('copy tags from selected image(s)'))
 
 -- shortcut for attach
-dt.register_event("shortcut",
+dt.register_event(CURR_API_STRING >= "6.2.1" and "cadt_at", "shortcut" or "shortcut" ,
                    attach_tags,
                    _('paste tags to selected image(s)'))
 
 -- shortcut for detaching tags
-dt.register_event("shortcut",
+dt.register_event(CURR_API_STRING >= "6.2.1" and "cadt_dt", "shortcut" or "shortcut" ,
                    detach_tags,
                    _('remove tags from selected image(s)'))
 
                    -- shortcut for replace tags
-dt.register_event("shortcut",
+dt.register_event(CURR_API_STRING >= "6.2.1" and "cadt_rt", "shortcut" or "shortcut" ,
                    replace_tags,
                    _('replace tags from selected image(s)'))
 

--- a/contrib/cr2hdr.lua
+++ b/contrib/cr2hdr.lua
@@ -37,6 +37,7 @@ local du = require "lib/dtutils"
 
 -- Tested with darktable 2.0.1
 du.check_min_api_version("2.0.0", "cr2hdr")
+local CURR_API_STRING = darktable.configuration.api_version_string
 
 local queue = {}
 local processed_files = {}
@@ -107,8 +108,11 @@ local function convert_action_images(shortcut)
     convert_images()
 end
 
-darktable.register_event("shortcut", convert_action_images, "Run cr2hdr (Magic Lantern DualISO converter) on selected images")
-darktable.register_event("post-import-image", file_imported)
-darktable.register_event("post-import-film", film_imported)
+darktable.register_event(CURR_API_STRING >= "6.2.1" and "cr2hdr", "shortcut" or "shortcut" , 
+    convert_action_images, "Run cr2hdr (Magic Lantern DualISO converter) on selected images")
+darktable.register_event(CURR_API_STRING >= "6.2.1" and "cr2hdr", "post-import-image" or "post-import-image" , 
+    file_imported)
+darktable.register_event(CURR_API_STRING >= "6.2.1" and "cr2hdr", "post-import-film" or "post-import-film" , 
+    film_imported)
 
 darktable.preferences.register("cr2hdr", "onimport", "bool", "Invoke on import", "If true then cr2hdr will try to proccess every file during importing. Warning: cr2hdr is quite slow even in figuring out on whether the file is Dual ISO or not.", false)

--- a/contrib/exportLUT.lua
+++ b/contrib/exportLUT.lua
@@ -34,6 +34,7 @@ local ds = require("lib/dtutils.system")
 local gettext = dt.gettext
 
 gettext.bindtextdomain("exportLUT",dt.configuration.config_dir.."/lua/locale/")
+local CURR_API_STRING = dt.configuration.api_version_string
 
 local function _(msgid)
     return gettext.dgettext("exportLUT", msgid)
@@ -161,7 +162,7 @@ if dt.gui.current_view().id == "lighttable" then
 else
   if not eL.event_registered then
     dt.register_event(
-      "view-changed",
+      CURR_API_STRING >= "6.2.1" and "exportLUT", "view-changed" or "view-changed" ,
       function(event, old_view, new_view)
         if new_view.name == "lighttable" and old_view.name == "darkroom" then
           install_module()

--- a/contrib/ext_editor.lua
+++ b/contrib/ext_editor.lua
@@ -75,6 +75,7 @@ local dtsys = require "lib/dtutils.system"
 
 -- module name
 local MODULE_NAME = "ext_editor"
+local CURR_API_STRING = dt.configuration.api_version_string
 
 
 -- check API version
@@ -416,7 +417,7 @@ if dt.gui.current_view().id == "lighttable" then
 else
   if not ee.event_registered then
     dt.register_event(
-      "view-changed",
+      CURR_API_STRING >= "6.2.1" and MODULE_NAME, "view-changed" or "view-changed" ,
       function(event, old_view, new_view)
         if new_view.name == "lighttable" and old_view.name == "darkroom" then
           install_module()
@@ -451,7 +452,8 @@ for i = MAX_EDITORS, 1, -1 do
 
 -- register the new shortcuts -------------------------------------------------
 for i = 1, MAX_EDITORS do
-  dt.register_event("shortcut", program_shortcut, _("edit with program ")..string.format("%02d", i)) 
+  dt.register_event(CURR_API_STRING >= "6.2.1" and MODULE_NAME .. i, "shortcut" or "shortcut" , 
+    program_shortcut, _("edit with program ")..string.format("%02d", i)) 
   end
 
 

--- a/contrib/face_recognition.lua
+++ b/contrib/face_recognition.lua
@@ -51,6 +51,7 @@ local gettext = dt.gettext
 local MODULE = "face_recognition"
 local PS = dt.configuration.running_os == "windows" and '\\' or '/'
 local OUTPUT = dt.configuration.tmp_dir .. PS .. "facerecognition.txt"
+local CURR_API_STRING = dt.configuration.api_version_string
 
 -- namespace
 
@@ -489,7 +490,7 @@ if dt.gui.current_view().id == "lighttable" then
 else
   if not fc.event_registered then
     dt.register_event(
-      "view-changed",
+      CURR_API_STRING >= "6.2.1" and MODULE, "view-changed" or "view-changed" ,
       function(event, old_view, new_view)
         if new_view.name == "lighttable" and old_view.name == "darkroom" then
           install_module()

--- a/contrib/fujifilm_dynamic_range.lua
+++ b/contrib/fujifilm_dynamic_range.lua
@@ -62,6 +62,7 @@ local du = require "lib/dtutils"
 local df = require "lib/dtutils.file"
 
 du.check_min_api_version("4.0.0", "fujifilm_dynamic_range")
+local CURR_API_STRING = dt.configuration.api_version_string
 
 local function detect_dynamic_range(event, image)
 	if image.exif_maker ~= "FUJIFILM" then
@@ -104,6 +105,7 @@ local function detect_dynamic_range(event, image)
 	dt.print_log("[fujifilm_dynamic_range] raw exposure bias " .. tostring(raf_result))
 end
 
-dt.register_event("post-import-image", detect_dynamic_range)
+dt.register_event(CURR_API_STRING >= "6.2.1" and "fujifilm_dr", "post-import-image" or "post-import-image" , 
+	detect_dynamic_range)
 
 dt.print_log("[fujifilm_dynamic_range] loaded")

--- a/contrib/fujifilm_ratings.lua
+++ b/contrib/fujifilm_ratings.lua
@@ -29,6 +29,7 @@ local df = require "lib/dtutils.file"
 local gettext = dt.gettext
 
 du.check_min_api_version("4.0.0", "fujifilm_ratings")
+local CURR_API_STRING = dt.configuration.api_version_string
 
 gettext.bindtextdomain("fujifilm_ratings", dt.configuration.config_dir.."/lua/locale/")
 
@@ -66,6 +67,7 @@ local function detect_rating(event, image)
 	end
 end
 
-dt.register_event("post-import-image", detect_rating)
+dt.register_event(CURR_API_STRING >= "6.2.1" and "fujifilm_rat", "post-import-image" or "post-import-image" , 
+	detect_rating)
 
 print(_("fujifilm_ratings loaded."))

--- a/contrib/geoToolbox.lua
+++ b/contrib/geoToolbox.lua
@@ -31,6 +31,7 @@ local df = require "lib/dtutils.file"
 local gettext = dt.gettext
 
 du.check_min_api_version("3.0.0", "geoToolbox") 
+local CURR_API_STRING = dt.configuration.api_version_string
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("geoToolbox",dt.configuration.config_dir.."/lua/locale/")
@@ -687,7 +688,7 @@ if dt.gui.current_view().id == "lighttable" then
 else
   if not gT.event_registered then
     dt.register_event(
-      "view-changed",
+      CURR_API_STRING >= "6.2.1" and "geoToolbox", "view-changed" or "view-chagned",
       function(event, old_view, new_view)
         if new_view.name == "lighttable" and old_view.name == "darkroom" then
           install_module()
@@ -707,11 +708,15 @@ dt.preferences.register("geoToolbox",
 	'' )
 
 -- Register
-dt.register_event("shortcut", print_calc_distance, _("Calculate the distance from latitude and longitude in km"))
-dt.register_event("mouse-over-image-changed", toolbox_calc_distance)
+dt.register_event(CURR_API_STRING >= "6.2.1" and "geoToolbox_cd", "shortcut" or "shortcut" , 
+  print_calc_distance, _("Calculate the distance from latitude and longitude in km"))
+dt.register_event(CURR_API_STRING >= "6.2.1" and "geoToolbox", "mouse-over-image-changed" or "mouse-over-image-changed" , 
+  toolbox_calc_distance)
 
-dt.register_event("shortcut", select_with_gps, _("Select all images with GPS information"))
-dt.register_event("shortcut", select_without_gps, _("Select all images without GPS information"))
+dt.register_event(CURR_API_STRING >= "6.2.1" and "geoToolbox_wg", "shortcut" or "shortcut" , 
+  select_with_gps, _("Select all images with GPS information"))
+dt.register_event(CURR_API_STRING >= "6.2.1" and "geoToolbox_ng", "shortcut" or "shortcut" , 
+  select_without_gps, _("Select all images without GPS information"))
 
 -- vim: shiftwidth=2 expandtab tabstop=2 cindent syntax=lua
 -- kate: hl Lua;

--- a/contrib/gpx_export.lua
+++ b/contrib/gpx_export.lua
@@ -28,6 +28,7 @@ local dl = require "lib/dtutils"
 local gettext = dt.gettext
 
 dl.check_min_api_version("3.0.0", "gpx-export") 
+local CURR_API_STRING = dt.configuration.api_version_string
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("gpx_export",dt.configuration.config_dir.."/lua/locale/")
@@ -173,7 +174,7 @@ if dt.gui.current_view().id == "lighttable" then
 else
   if not gpx.event_registered then
     dt.register_event(
-      "view-changed",
+      CURR_API_STRING >= "6.2.1" and "gpx_export", "view-changed" or "view-changed" ,
       function(event, old_view, new_view)
         if new_view.name == "lighttable" and old_view.name == "darkroom" then
           install_module()

--- a/contrib/image_time.lua
+++ b/contrib/image_time.lua
@@ -114,6 +114,7 @@ img_time.module_installed = false
 img_time.event_registered = false
 
 du.check_min_api_version("3.0.0", "image_time") 
+local CURR_API_STRING = dt.configuration.api_version_string
 
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
@@ -551,7 +552,7 @@ if dt.gui.current_view().id == "lighttable" then
 else
   if not img_time.event_registered then
     dt.register_event(
-      "view-changed",
+      CURR_API_STRING >= "6.2.1" and "image_time", "view-changed" or "view-changed" ,
       function(event, old_view, new_view)
         if new_view.name == "lighttable" and old_view.name == "darkroom" then
           install_module()

--- a/contrib/photils.lua
+++ b/contrib/photils.lua
@@ -44,6 +44,7 @@ local dtsys = require "lib/dtutils.system"
 local MODULE_NAME = "photils"
 du.check_min_api_version("5.0.0", MODULE_NAME)
 
+local CURR_API_STRING = dt.configuration.api_version_string
 local PS = dt.configuration.running_os == "windows" and "\\" or "/"
 local gettext = dt.gettext
 gettext.bindtextdomain(MODULE_NAME,
@@ -433,14 +434,15 @@ dt.preferences.register(MODULE_NAME,
                         _("if enabled, the confidence value for each tag is displayed"),
                         true)
 
-dt.register_event("mouse-over-image-changed",PHOTILS.image_changed)
+dt.register_event(CURR_API_STRING >= "6.2.1" and "photils", "mouse-over-image-changed" or "mouse-over-image-changed" ,
+    PHOTILS.image_changed)
 
 if dt.gui.current_view().id == "lighttable" then
   install_module()
 else
   if not PHOTILS.event_registered then
     dt.register_event(
-      "view-changed",
+      CURR_API_STRING >= "6.2.1" and "photils", "view-changed" or "view-changed",
       function(event, old_view, new_view)
         if new_view.name == "lighttable" and old_view.name == "darkroom" then
           install_module()

--- a/contrib/quicktag.lua
+++ b/contrib/quicktag.lua
@@ -57,6 +57,7 @@ qt.widget_table = {}
 local gettext = dt.gettext
 
 du.check_min_api_version("3.0.0", "quicktag")
+local CURR_API_STRING = dt.configuration.api_version_string
 
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("quicktag",dt.configuration.config_dir.."/lua/locale/")
@@ -256,7 +257,7 @@ if dt.gui.current_view().id == "lighttable" then
 else
   if not qt.event_registered then
     dt.register_event(
-      "view-changed",
+      CURR_API_STRING >= "6.2.1" and "quicktag", "view-changed" or "view-changed" ,
       function(event, old_view, new_view)
         if new_view.name == "lighttable" and old_view.name == "darkroom" then
           install_module()
@@ -269,7 +270,7 @@ end
 
 -- create shortcuts
 for i=1,qnr do
-  dt.register_event("shortcut",
+  dt.register_event(CURR_API_STRING >= "6.2.1" and "quicktag", "shortcut" or "shortcut" ,
 		   function(event, shortcut) tagattach(tostring(quicktag_table[i])) end,
 		  string.format(_("quicktag %i"),i))
 end

--- a/contrib/rate_group.lua
+++ b/contrib/rate_group.lua
@@ -43,6 +43,7 @@ local du = require "lib/dtutils"
 
 -- added version check
 du.check_min_api_version("3.0.0", "rate_group") 
+local CURR_API_STRING = dt.configuration.api_version_string
 
 local function apply_rating(rating)
   local images = dt.gui.action_images
@@ -59,30 +60,37 @@ local function apply_rating(rating)
   end
 end
 
-dt.register_event("shortcut",function(event, shortcut)
+dt.register_event(CURR_API_STRING >= "6.2.1" and "rg_reject", "shortcut" or "shortcut" ,
+  function(event, shortcut)
     apply_rating(-1)
 end, "Reject group")
 
-dt.register_event("shortcut",function(event, shortcut)
+dt.register_event(CURR_API_STRING >= "6.2.1" and "rg0", "shortcut" or "shortcut",
+  function(event, shortcut)
     apply_rating(0)
 end, "Rate group 0")
 
-dt.register_event("shortcut",function(event, shortcut)
+dt.register_event(CURR_API_STRING >= "6.2.1" and "rg1", "shortcut" or "shortcut",
+  function(event, shortcut)
     apply_rating(1)
 end, "Rate group 1")
 
-dt.register_event("shortcut",function(event, shortcut)
+dt.register_event(CURR_API_STRING >= "6.2.1" and "rg2", "shortcut" or "shortcut",
+  function(event, shortcut)
     apply_rating(2)
 end, "Rate group 2")
 
-dt.register_event("shortcut",function(event, shortcut)
+dt.register_event(CURR_API_STRING >= "6.2.1" and "rg3", "shortcut" or "shortcut",
+  function(event, shortcut)
     apply_rating(3)
 end, "Rate group 3")
 
-dt.register_event("shortcut",function(event, shortcut)
+dt.register_event(CURR_API_STRING >= "6.2.1" and "rg4", "shortcut" or "shortcut",
+  function(event, shortcut)
     apply_rating(4)
 end, "Rate group 4")
 
-dt.register_event("shortcut",function(event, shortcut)
+dt.register_event(CURR_API_STRING >= "6.2.1" and "rg5", "shortcut" or "shortcut",
+  function(event, shortcut)
     apply_rating(5)
 end, "Rate group 5")

--- a/contrib/rename-tags.lua
+++ b/contrib/rename-tags.lua
@@ -34,6 +34,7 @@ local debug = require "darktable.debug"
 
 -- check API version
 du.check_min_api_version("3.0.0", "rename-tags") 
+local CURR_API_STRING = darktable.configuration.api_version_string
 
 local rt = {}
 rt.module_installed = false
@@ -136,7 +137,7 @@ if darktable.gui.current_view().id == "lighttable" then
 else
   if not rt.event_registered then
     darktable.register_event(
-      "view-changed",
+      CURR_API_STRING >= "6.2.1" and "rename_tags", "view-changed" or "view-changed" ,
       function(event, old_view, new_view)
         if new_view.name == "lighttable" and old_view.name == "darkroom" then
           install_module()

--- a/contrib/slideshowMusic.lua
+++ b/contrib/slideshowMusic.lua
@@ -31,6 +31,8 @@ local gettext = dt.gettext
 
 du.check_min_api_version("2.0.2", "slideshowMusic") 
 
+local CURR_API_STRING = dt.configuration.api_version_string
+
 -- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("slideshowMusic",dt.configuration.config_dir.."/lua/locale/")
 
@@ -76,4 +78,5 @@ dt.preferences.register("slideshowMusic",
                         _("Plays music with rhythmbox if a slideshow starts"),
                         true)
 -- Register
-dt.register_event("view-changed",playSlideshowMusic)
+dt.register_event(CURR_API_STRING >= "6.2.1" and "slideshow_music", "view-changed" or "view-changed" ,
+  playSlideshowMusic)

--- a/contrib/transfer_hierarchy.lua
+++ b/contrib/transfer_hierarchy.lua
@@ -83,6 +83,7 @@ dtutils.check_min_api_version("5.0.0", LIB_ID)
 local MKDIR_COMMAND = darktable.configuration.running_os == "windows" and "mkdir " or "mkdir -p "
 local PATH_SEPARATOR = darktable.configuration.running_os == "windows" and "\\\\"  or  "/"
 local PATH_SEGMENT_REGEX = "(" .. PATH_SEPARATOR .. "?)([^" .. PATH_SEPARATOR .. "]+)"
+local CURR_API_STRING = darktable.configuration.api_version_string
 
 unpack = unpack or table.unpack
 gmatch = string.gfind or string.gmatch
@@ -366,7 +367,7 @@ if darktable.gui.current_view().id == "lighttable" then
 else
   if not th.event_registered then
     darktable.register_event(
-      "view-changed",
+      CURR_API_STRING >= "6.2.1" and LIB_ID, "view-changed" or "view-changed" ,
       function(event, old_view, new_view)
         if new_view.name == "lighttable" and old_view.name == "darkroom" then
           install_module()

--- a/examples/moduleExample.lua
+++ b/examples/moduleExample.lua
@@ -34,6 +34,7 @@ local dt = require "darktable"
 local du = require "lib/dtutils"
 
 du.check_min_api_version("3.0.0", "moduleExample") 
+local CURR_API_STRING = dt.configuration.api_version_string
 
 -- translation
 
@@ -147,7 +148,7 @@ else
   if not mE.event_registered then -- if we are not in lighttable view then register an event to signal when we might be
     -- https://www.darktable.org/lua-api/index.html#darktable_register_event
     dt.register_event(
-      "view-changed",  -- we want to be informed when the view changes
+      CURR_API_STRING >= "6.2.1" and "mdouleExample", "view-changed" or "view-chagned" ,  -- we want to be informed when the view changes
       function(event, old_view, new_view)
         if new_view.name == "lighttable" and old_view.name == "darkroom" then  -- if the view changes from darkroom to lighttable
           install_module()  -- register the lib

--- a/examples/multi_os.lua
+++ b/examples/multi_os.lua
@@ -62,6 +62,7 @@ local dt = require "darktable"
 local du = require "lib/dtutils"  -- utilities
 local df = require "lib/dtutils.file"   -- file utilities
 local dtsys = require "lib/dtutils.system"  -- system utilities
+local CURR_API_STRING = dt.configuration.api_version_string
 
 --[[
     darktable is an international program, and it's user interface has been translated into
@@ -240,7 +241,7 @@ dt.gui.libs.image.register_action(
 ]]
 
 dt.register_event(
-  "shortcut",
+  CURR_API_STRING >= "6.2.1" and "multi_os", "shortcut" or "shortcut" ,
   function(event, shortcut) extract_embedded_jpeg(dt.gui.action_images) end,
   "extract embedded jpeg"
 )

--- a/official/copy_paste_metadata.lua
+++ b/official/copy_paste_metadata.lua
@@ -30,6 +30,7 @@ local du = require "lib/dtutils"
 local gettext = dt.gettext
 
 du.check_min_api_version("3.0.0", "copy_paste_metadata")
+local CURR_API_STRING = dt.configuration.api_version_string
 
 -- set this to "false" if you don't want to overwrite metadata fields
 -- (title, description, creator, publisher and rights) that are already set
@@ -125,13 +126,13 @@ dt.gui.libs.image.register_action(
 )
 
 dt.register_event(
-  "shortcut",
+  CURR_API_STRING >= "6.2.1" and "capmd1", "shortcut" or "shortcut" ,
   function(event, shortcut) copy(dt.gui.action_images[1]) end,
   "copy metadata"
 )
 
 dt.register_event(
-  "shortcut",
+  CURR_API_STRING >= "6.2.1" and "capmd2", "shortcut" or "shortcut" ,
   function(event, shortcut) paste(dt.gui.action_images) end,
   "paste metadata"
 )

--- a/official/enfuse.lua
+++ b/official/enfuse.lua
@@ -38,6 +38,7 @@ local df = require "lib/dtutils.file"
 local dtsys = require "lib/dtutils.system"
 
 local PS = dt.configuration.running_os == "windows" and "\\" or "/"
+local CURR_API_STRING = dt.configuration.api_version_string
 
 local gettext = dt.gettext
 
@@ -268,7 +269,7 @@ if enfuse_installed then
   else
     if not enf.event_registered then
       dt.register_event(
-        "view-changed",
+        CURR_API_STRING >= "6.2.1" and "enfuse", "view-changed" or "view-chagned" ,
         function(event, old_view, new_view)
           if new_view.name == "lighttable" and old_view.name == "darkroom" then
             install_module()

--- a/official/generate_image_txt.lua
+++ b/official/generate_image_txt.lua
@@ -39,6 +39,7 @@ local du = require "lib/dtutils"
 require "darktable.debug"
 
 du.check_min_api_version("2.1.0", "generate_image_txt") 
+local CURR_API_STRING = dt.configuration.api_version_string
 
 dt.preferences.register("generate_image_txt",
                         "enabled",
@@ -65,7 +66,8 @@ end
 local command_setting = dt.preferences.read("generate_image_txt", "command", "string")
 check_command(command_setting)
 
-dt.register_event("mouse-over-image-changed", function(event, img)
+dt.register_event(CURR_API_STRING >= "6.2.1" and "gen_img_txt", "mouse-over-image-changed" or "mouse-over-image-chagned" , 
+    function(event, img)
     -- no need to waste processing time if the image has a txt file already
     if not img or img.has_txt or not dt.preferences.read("generate_image_txt", "enabled", "bool") then
       return

--- a/official/image_path_in_ui.lua
+++ b/official/image_path_in_ui.lua
@@ -32,6 +32,7 @@ local dt = require "darktable"
 local du = require "lib/dtutils"
 
 du.check_min_api_version("2.0.0", "image_path_in_ui") 
+local CURR_API_STRING = dt.configuration.api_version_string
 
 local ipiu = {}
 ipiu.module_installed = false
@@ -73,7 +74,7 @@ if dt.gui.current_view().id == "lighttable" then
 else
   if not ipiu.event_registered then
     dt.register_event(
-      "view-changed",
+      CURR_API_STRING >= "6.2.1" and "ipiu", "view-changed" or "view-changed" ,
       function(event, old_view, new_view)
         if new_view.name == "lighttable" and old_view.name == "darkroom" then
           install_module()
@@ -84,7 +85,7 @@ else
   end
 end
 
-dt.register_event("mouse-over-image-changed",reset_widget);
+dt.register_event(CURR_API_STRING >= "6.2.1" and "ipiu", "mouse-over-image-changed" or "mouse-over-image-changed" , reset_widget);
 
   --
 -- vim: shiftwidth=2 expandtab tabstop=2 cindent syntax=lua

--- a/official/import_filter_manager.lua
+++ b/official/import_filter_manager.lua
@@ -34,6 +34,7 @@ local dt = require "darktable"
 
 local import_filter_list = {}
 local n_import_filters = 1
+local CURR_API_STRING = dt.configuration.api_version_string
 
 -- allow changing the filter from the preferences
 dt.preferences.register("import_filter_manager", "active_filter", "string",
@@ -56,7 +57,7 @@ dt.gui.libs.import.register_widget(filter_dropdown)
 
 
 -- this is just a wrapper which calls the active import filter
-dt.register_event("pre-import", function(event, images)
+dt.register_event(CURR_API_STRING >= "6.2.1" and "ifm", "pre-import" or "pre-import" , function(event, images)
   local active_filter = dt.preferences.read("import_filter_manager", "active_filter", "string")
   if active_filter == "" then return end
   local callback = import_filter_list[active_filter]

--- a/official/save_selection.lua
+++ b/official/save_selection.lua
@@ -37,21 +37,22 @@ local dt = require "darktable"
 local du = require "lib/dtutils"
 
 du.check_min_api_version("2.0.0", "save_selection") 
+local CURR_API_STRING = dt.configuration.api_version_string
 
 local buffer_count = 5
 
 for i=1,buffer_count do
   local saved_selection
-  dt.register_event("shortcut",function()
+  dt.register_event(CURR_API_STRING >= "6.2.1" and "save_selection", "shortcut" or "shortcut" ,function()
     saved_selection = dt.gui.selection()
   end,"save to buffer "..i)
-  dt.register_event("shortcut",function()
+  dt.register_event(CURR_API_STRING >= "6.2.1" and "save_selection1", "shortcut" or "shortcut" ,function()
     dt.gui.selection(saved_selection)
   end,"restore from buffer "..i)
 end
 
 local bounce_buffer = {}
-dt.register_event("shortcut",function()
+dt.register_event(CURR_API_STRING >= "6.2.1" and "save_selection2", "shortcut" or "shortcut" ,function()
   bounce_buffer = dt.gui.selection(bounce_buffer)
 end,"switch selection with temporary buffer")
 

--- a/tools/executable_manager.lua
+++ b/tools/executable_manager.lua
@@ -37,6 +37,7 @@ du.check_min_api_version("5.0.0", "executable_manager")
 local PS = dt.configuration.running_os == "windows" and "\\" or "/"
 
 local gettext = dt.gettext
+local CURR_API_STRING = dt.configuration.api_version_string
 
 gettext.bindtextdomain("executable_manager",dt.configuration.config_dir.."/lua/locale/")
 
@@ -214,7 +215,7 @@ if dt.gui.current_view().id == "lighttable" then
 else
   if not exec_man.event_registered then
     dt.register_event(
-      "view-changed",
+      CURR_API_STRING >= "6.2.1" and "executable_manager", "view-changed" or "view-changed" ,
       function(event, old_view, new_view)
         if new_view.name == "lighttable" and old_view.name == "darkroom" then
           install_module()

--- a/tools/script_manager.lua
+++ b/tools/script_manager.lua
@@ -882,7 +882,7 @@ if dt.gui.current_view().id == "lighttable" then
 else
   if not sm.event_registered then
     dt.register_event(
-      "view-changed",
+      CURR_API_STRING >= "6.2.1" and "script_manager", "view-changed" or "view-changed" ,
       function(event, old_view, new_view)
         if new_view.name == "lighttable" and old_view.name == "darkroom" then
           install_module()


### PR DESCRIPTION
Made changes to darktable.register_event calls so they are compatible with Lua API 6.2.1 which maintaining compatibility with Lua API 6.1.0.