### PR TITLE
Fixed OpenInExplorer.lua so that it works with the latest Darktable r…

### DIFF
--- a/contrib/OpenInExplorer.lua
+++ b/contrib/OpenInExplorer.lua
@@ -50,7 +50,6 @@ As an alternative option you can choose to show the image file names as symbolic
 local dt = require "darktable"
 local du = require "lib/dtutils"
 local df = require "lib/dtutils.file"
-           require "lib/darktable_transition"
 local dsys = require "lib/dtutils.system"
 local gettext = dt.gettext
 
@@ -210,7 +209,7 @@ if act_os ~= "windows" then
 end
 
 dt.register_event(
-    "OpenInExplorer", "shortcut",
+    "shortcut",
     function(event, shortcut) open_in_fmanager() end,
     "OpenInExplorer"
 )  


### PR DESCRIPTION
…elease (3.4.0 for the API v6.1.0).

Tested on Windows 10 - previously the script would not load, giving an error popup in the darktable GUI.