### PR TITLE
External editors: make gui visible in darkroom

### DIFF
--- a/contrib/ext_editor.lua
+++ b/contrib/ext_editor.lua
@@ -337,23 +337,40 @@ local function export2collection(storage, image_table, extra_data)
 
 
 -- install the module in the UI -----------------------------------------------
-local function install_module()
+local function install_module(dr)
   if not ee.module_installed then
-    -- register new module "external editors" in lighttable and darkroom ------
-    dt.register_lib(
-      MODULE_NAME,          
-      _("external editors"),  
-      true, -- expandable
-      false,  -- resetable
-      {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 100},
-       [dt.gui.views.darkroom] = {"DT_UI_CONTAINER_PANEL_LEFT_CENTER", 100}},  
-      dt.new_widget("box") {
-        orientation = "vertical",
-        table.unpack(ee.widgets),
-        },
-      nil,  -- view_enter
-      nil   -- view_leave
-      )
+    if dr then
+      -- register new module "external editors" in lighttable and darkroom ----
+      dt.register_lib(
+        MODULE_NAME,          
+        _("external editors"),  
+        true, -- expandable
+        false,  -- resetable
+        {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 100},
+         [dt.gui.views.darkroom] = {"DT_UI_CONTAINER_PANEL_LEFT_CENTER", 100}},  
+        dt.new_widget("box") {
+          orientation = "vertical",
+          table.unpack(ee.widgets),
+          },
+        nil,  -- view_enter
+        nil   -- view_leave
+        )
+    else 
+      -- register new module "external editors" in lighttable only ------------
+      dt.register_lib(
+        MODULE_NAME,          
+        _("external editors"),  
+        true, -- expandable
+        false,  -- resetable
+        {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 100}},  
+        dt.new_widget("box") {
+          orientation = "vertical",
+          table.unpack(ee.widgets),
+          },
+        nil,  -- view_enter
+        nil   -- view_leave
+        )
+    end
     ee.module_installed = true
   end
 end
@@ -417,15 +434,16 @@ table.insert(ee.widgets, box1)
 
 
 -- register new module, but only when in lighttable ----------------------------
+local show_dr = dt.preferences.read(MODULE_NAME, "show_in_darkrooom", "bool")
 if dt.gui.current_view().id == "lighttable" then
-  install_module()
+  install_module(show_dr)
 else
   if not ee.event_registered then
     dt.register_event(
       MODULE_NAME, "view-changed",
       function(event, old_view, new_view)
         if new_view.name == "lighttable" and old_view.name == "darkroom" then
-          install_module()
+          install_module(show_dr)
          end
       end
     )
@@ -452,6 +470,9 @@ for i = MAX_EDITORS, 1, -1 do
   _("name of external editor ")..i, 
   _("friendly name of external editor"), "")
   end
+dt.preferences.register(MODULE_NAME, "show_in_darkrooom", "bool", 
+  _("show external editors in darkroom"), 
+  _("check to show external editors module also in darkroom (requires restart)"), false)
 
 
 -- register the new shortcuts -------------------------------------------------

--- a/contrib/ext_editor.lua
+++ b/contrib/ext_editor.lua
@@ -99,7 +99,7 @@ local function _(msgid)
   end
 
 -- maximum number of external programs, can be increased to necessity
-local MAX_EDITORS = 12
+local MAX_EDITORS = 9
 
 -- number of valid entries in the list of external programs
 local n_entries

--- a/contrib/ext_editor.lua
+++ b/contrib/ext_editor.lua
@@ -411,10 +411,28 @@ local box1 = dt.new_widget("box") {
   }
 
 
--- install module in lighttable and darkroom ----------------------------------
+-- table with all the widgets --------------------------------------------------
 table.insert(ee.widgets, combobox)
 table.insert(ee.widgets, box1)
-install_module()
+
+
+-- register new module, but only when in lighttable ----------------------------
+if dt.gui.current_view().id == "lighttable" then
+  install_module()
+else
+  if not ee.event_registered then
+    dt.register_event(
+      MODULE_NAME, "view-changed",
+      function(event, old_view, new_view)
+        if new_view.name == "lighttable" and old_view.name == "darkroom" then
+          install_module()
+         end
+      end
+    )
+    ee.event_registered = true
+  end
+end
+
 
 -- initialize list of programs and widgets ------------------------------------ 
 UpdateProgramList(combobox, button_edit, button_edit_copy, false) 

--- a/contrib/ext_editor.lua
+++ b/contrib/ext_editor.lua
@@ -416,6 +416,9 @@ table.insert(ee.widgets, combobox)
 table.insert(ee.widgets, box1)
 install_module()
 
+-- initialize list of programs and widgets ------------------------------------ 
+UpdateProgramList(combobox, button_edit, button_edit_copy, false) 
+
 
 -- register new storage -------------------------------------------------------
 dt.register_storage("exp2coll", _("collection"), nil, export2collection)

--- a/contrib/ext_editor.lua
+++ b/contrib/ext_editor.lua
@@ -338,39 +338,28 @@ local function export2collection(storage, image_table, extra_data)
 
 -- install the module in the UI -----------------------------------------------
 local function install_module(dr)
+  
+  local views = {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 100}}
+  if dr then 
+    views = {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 100},
+            [dt.gui.views.darkroom] = {"DT_UI_CONTAINER_PANEL_LEFT_CENTER", 100}}
+  end
+  
   if not ee.module_installed then
-    if dr then
-      -- register new module "external editors" in lighttable and darkroom ----
-      dt.register_lib(
-        MODULE_NAME,          
-        _("external editors"),  
-        true, -- expandable
-        false,  -- resetable
-        {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 100},
-         [dt.gui.views.darkroom] = {"DT_UI_CONTAINER_PANEL_LEFT_CENTER", 100}},  
-        dt.new_widget("box") {
-          orientation = "vertical",
-          table.unpack(ee.widgets),
-          },
-        nil,  -- view_enter
-        nil   -- view_leave
-        )
-    else 
-      -- register new module "external editors" in lighttable only ------------
-      dt.register_lib(
-        MODULE_NAME,          
-        _("external editors"),  
-        true, -- expandable
-        false,  -- resetable
-        {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER", 100}},  
-        dt.new_widget("box") {
-          orientation = "vertical",
-          table.unpack(ee.widgets),
-          },
-        nil,  -- view_enter
-        nil   -- view_leave
-        )
-    end
+    -- register new module "external editors" in lighttable and darkroom ----
+    dt.register_lib(
+      MODULE_NAME,          
+      _("external editors"),  
+      true, -- expandable
+      false,  -- resetable
+      views,
+      dt.new_widget("box") {
+        orientation = "vertical",
+        table.unpack(ee.widgets),
+        },
+      nil,  -- view_enter
+      nil   -- view_leave
+      )
     ee.module_installed = true
   end
 end


### PR DESCRIPTION
With the recent introduction of export module in darkroom it comes in handy to make ext_editor.lua GUI visible in darkroom as well.
With this, we can export to collection and make round trips to our favorite program, all without leaving darkroom and not being forved to rely on keyboard shortcut only.
