### PR TITLE
photils plugin

### DIFF
--- a/contrib/photils.lua
+++ b/contrib/photils.lua
@@ -237,9 +237,9 @@ function PHOTILS.attach_tags()
         end
 
         job.percent = i / num_selected
-        dt.print(_("Tags successfully attached to image"))
     end
 
+    dt.print(_("Tags successfully attached to image"))
     job.valid = false
 end
 


### PR DESCRIPTION
This merge request addresses issue #311 by adding an additional preference property to manually enable/disable the pre-export of images by the user. Additionally, it is now possible to request tag suggestions for a single image and apply those to multiple images. 