### PR TITLE
Fix contrib/quicktag

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 ## Changes from most recent to oldest
 
+** 02 Jun 2021 - wpferguson - fix contrib/quicktag**
+* set new entry field is_password to false so entry
+is visible to user while typing.
+
 ** 19 Mar 2021 - wpferguson - fixed crash in contrib/HDRmerge.lua**
 * Made generated filename routine gracefully handle names that
 are not in the expected format.

--- a/contrib/quicktag.lua
+++ b/contrib/quicktag.lua
@@ -211,7 +211,7 @@ update_quicktag_list()
 local new_quicktag = dt.new_widget("entry"){
     text = "",
     placeholder = _("new tag"),
-    is_password = true,
+    is_password = false,
     editable = true,
     tooltip = _("enter your tag here")
 }


### PR DESCRIPTION
changed new entry field `is_password` setting to false  so that the user can see what they are typing.