### PR TITLE
add harmonic armature guide

### DIFF
--- a/contrib/harmonic_armature_guide.lua
+++ b/contrib/harmonic_armature_guide.lua
@@ -1,0 +1,84 @@
+--[[
+  harmonic artmature guide for darktable
+
+  copyright (c) 2021  Hubert Kowalski
+  
+  darktable is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  darktable is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+]]
+
+--[[
+HARMONIC ARMATURE GUIDE
+Harmonic Armature (also known as 14 line armature)
+
+INSTALLATION
+* copy this file in $CONFIGDIR/lua/ where CONFIGDIR is your darktable configuration directory
+* add the following line in the file $CONFIGDIR/luarc
+  require "harmonic_armature_guide"
+
+USAGE
+* when using guides, select "harmonic armature" as guide
+]]
+
+local dt = require "darktable"
+local du = require "lib/dtutils"
+local gettext = dt.gettext
+
+du.check_min_api_version("2.0.0", "harmonic_armature_guide") 
+
+-- Tell gettext where to find the .mo file translating messages for a particular domain
+gettext.bindtextdomain("harmonic_armature_guide",dt.configuration.config_dir.."/lua/locale/")
+
+local function _(msgid)
+  return gettext.dgettext("harmonic_armature_guide", msgid)
+end
+
+dt.guides.register_guide("harmonic armature",
+-- draw
+function(cairo, x, y, width, height, zoom_scale)
+  cairo:save()
+
+  cairo:translate(x, y)
+  cairo:scale(width, height)
+
+  cairo:move_to(0,0)
+  cairo:line_to(1, 0.5)
+  cairo:line_to(0.5, 1)
+  cairo:line_to(0,0)
+  cairo:line_to(1, 1)
+  cairo:line_to(0.5, 0)
+  cairo:line_to(0, 0.5)
+  cairo:line_to(1, 1)
+
+  cairo:move_to(1, 0)
+  cairo:line_to(0, 0.5)
+  cairo:line_to(0.5, 1)
+  cairo:line_to(1, 0)
+  cairo:line_to(0, 1)
+  cairo:line_to(0.5, 0)
+  cairo:line_to(1, 0.5)
+  cairo:line_to(0, 1)
+
+  -- middle lines - not needed for harmonic armature
+  -- cairo:move_to(0,0.5)
+  -- cairo:line_to(1,0.5)
+  -- cairo:move_to(0.5,0)
+  -- cairo:line_to(0.5,1)
+
+  cairo:restore()
+end,
+-- gui
+function()
+  return dt.new_widget("label"){label = _("harmonic armature"), halign = "start"}
+end
+)

--- a/contrib/harmonic_armature_guide.lua
+++ b/contrib/harmonic_armature_guide.lua
@@ -22,9 +22,9 @@ HARMONIC ARMATURE GUIDE
 Harmonic Armature (also known as 14 line armature)
 
 INSTALLATION
-* copy this file in $CONFIGDIR/lua/ where CONFIGDIR is your darktable configuration directory
+* copy this file in $CONFIGDIR/lua/contrib where CONFIGDIR is your darktable configuration directory
 * add the following line in the file $CONFIGDIR/luarc
-  require "harmonic_armature_guide"
+  require "contrib/harmonic_armature_guide"
 
 USAGE
 * when using guides, select "harmonic armature" as guide
@@ -68,12 +68,6 @@ function(cairo, x, y, width, height, zoom_scale)
   cairo:line_to(0.5, 0)
   cairo:line_to(1, 0.5)
   cairo:line_to(0, 1)
-
-  -- middle lines - not needed for harmonic armature
-  -- cairo:move_to(0,0.5)
-  -- cairo:line_to(1,0.5)
-  -- cairo:move_to(0.5,0)
-  -- cairo:line_to(0.5,1)
 
   cairo:restore()
 end,


### PR DESCRIPTION
Based on guide I made here: https://discuss.pixls.us/t/add-custom-guides/26288/10?u=johnny-bit

It's actually harmonic armature guide and not dynamic symmetry guide.

How to use harmonic armature: https://www.thomaskegler.com/files/documents/compostion.pdf

additionally this essentially fixes https://github.com/darktable-org/darktable/issues/3139 since adding new guides via lua is good way.

@wpferguson - one question: i commented out the unnecessary middle lines (harmonic armature doesn't use middle lines), but i've seen places where they select and create additional lines. In normal c-coded darktable guides, the widgets allow for options but i have no idea how to add those in lua. I'd love to have this merged as-is and add options later if ever.