### PR TITLE
Deprecate rename-tags.lua

### DIFF
--- a/contrib/rename-tags.lua
+++ b/contrib/rename-tags.lua
@@ -34,6 +34,7 @@ local debug = require "darktable.debug"
 
 -- check API version
 du.check_min_api_version("7.0.0", "rename-tags") 
+du.deprecated("contrib/rename-tags.lua","darktable release 4.0")
 
 -- return data structure for script_manager
 

--- a/lib/dtutils.lua
+++ b/lib/dtutils.lua
@@ -330,4 +330,29 @@ function dtutils.find_image_by_id(imgid)
     end
 end
 
+dtutils.libdoc.functions["deprecated"] = {
+  Name = [[deprecated]],
+  Synopsis = [[print deprecation warning]],
+  Usage = [[local du = require "lib/dtutils"
+
+    du.deprecated(script_name, removal_string)
+      script_name - name of the script being deprecated
+      removal_strubg - a string explaining when the script will be removed]],
+  Description = [[deprecated prints an error message saying the script is deprecated and when it will be removed]],
+  Return_Value = [[]],
+  Limitations = [[]],
+  Example = [[local du = require "lib/dtutils"
+              du.deprecated("contrib/rename-tags.lua", "darktable release 4.0")]],
+  See_Also = [[]],
+  Reference = [[]],
+  License = [[]],
+  Copyright = [[]],
+}
+
+function dtutils.deprecated(script_name, removal_string)
+  dt.print_toast("WARNING: " .. script_name .. " is deprecated and will be removed in " .. removal_string)
+  dt.print_error("WARNING: " .. script_name .. " is deprecated and will be removed in " .. removal_string)
+end
+
+
 return dtutils


### PR DESCRIPTION
Tag renaming functionality is now included in core, thus removing the need for rename-tags.lua.

Added a deprecated function to lib/dtutils.lua for use when deprecating other scripts.

This issue is discussed in https://github.com/darktable-org/darktable/pull/10669