### PR TITLE
Fix dtutils/file.lua deprecation warning

### DIFF
--- a/lib/dtutils/file.lua
+++ b/lib/dtutils/file.lua
@@ -191,7 +191,7 @@ end
 
 local function _search_for_bin_nix(bin)
   local result = false
-  local p = io.popen("which " .. bin)
+  local p = io.popen("command -v " .. bin)
   local output = p:read("*a")
   p:close()
   if string.len(output) > 0 then


### PR DESCRIPTION
Replaced deprecated **which** command with **command -v**

Fixes #369