### PR TITLE
Added DNG to list of allowed file types for external editor

### DIFF
--- a/contrib/ext_editor.lua
+++ b/contrib/ext_editor.lua
@@ -108,7 +108,7 @@ local n_entries
 
 
 -- allowed file extensions for external editors
-local allowed_file_types = {"JPG", "jpg", "JPEG", "jpeg", "TIF", "tif", "TIFF", "tiff", "EXR", "exr", "PNG", "png"}
+local allowed_file_types = {"JPG", "jpg", "JPEG", "jpeg", "TIF", "tif", "TIFF", "tiff", "EXR", "exr", "PNG", "png", "DNG", "dng"}
 
 
 -- last used editor initialization


### PR DESCRIPTION
I tried to preprocess my images with Topaz DeNoise but was not allowed to open the DNG files with an external editor. 
I think, DNG is a common file type for external image processing programs so it should be allowed globally.
At least in this usecase, it works perfectly. DeNoise will write its output to the DNG and it is updated in dt.