### PR TITLE
Added tooltip to filter manager to better match new import scheme.

### DIFF
--- a/official/import_filter_manager.lua
+++ b/official/import_filter_manager.lua
@@ -45,6 +45,7 @@ local filter_dropdown = dt.new_widget("combobox")
 {
   label = "import filter",
   editable = false,
+  tooltip = "import filters are applied after completion of the import dialog",
 
   changed_callback = function(widget)
     dt.preferences.write("import_filter_manager", "active_filter", "string", widget.value)


### PR DESCRIPTION
The new import dialog does not immediately reflect the settings of the filter manager lua script, which made me wonder if it still works after upgrading from dt 3.2 to dt 3.8. It works, but does not fit very well to the new layout. A tooltip could prevent others to do the test themselves.