### PR TITLE
Change window position of executable_manager and script_manager

### DIFF
--- a/tools/executable_manager.lua
+++ b/tools/executable_manager.lua
@@ -106,7 +106,7 @@ local function install_module()
       "executable manager",     -- Visible name
       true,                -- expandable
       false,               -- resetable
-      {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_LEFT_BOTTOM", 100}},   -- containers
+      {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_LEFT_BOTTOM", 600}},   -- containers
       dt.new_widget("box") -- widget
       {
         orientation = "vertical",

--- a/tools/script_manager.lua
+++ b/tools/script_manager.lua
@@ -933,7 +933,7 @@ local function install_module()
       "script manager",     -- Visible name
       true,                -- expandable
       false,               -- resetable
-      {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_LEFT_BOTTOM", 600}},   -- containers
+      {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_LEFT_BOTTOM", 100}},   -- containers
       sm.widgets.main_box,
       nil,-- view_enter
       nil -- view_leave


### PR DESCRIPTION
Moved script_manager to bottom of lower left panel and placed executable_manager above it to work around windows GTK positioning issue.

Fixes #425 