### PR TITLE
Explicitly set non running scripts to FALSE

### DIFF
--- a/tools/script_manager.lua
+++ b/tools/script_manager.lua
@@ -467,6 +467,8 @@ local function add_script_name(name, path, category)
   table.insert(sm.scripts[category], script)
   if pref_read(script.script_name, "bool") then
     activate(script)
+  else
+    pref_write(script.script_name, "bool", false)
   end
   restore_log_level(old_log_level)
 end


### PR DESCRIPTION
Explicitly set non running scripts to FALSE instead of relying on no value being interpreted as false.

This prevents a reoccurrence of https://github.com/darktable-org/darktable/issues/15280

Fixes #429