### PR TITLE
[feature] select non existing images

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ change_group_leader|Yes|LMW|Change which image leads group
 [rename_images](https://darktable-org.github.io/luadocs/lua.scripts.manual/scripts/contrib/rename_images)|Yes|LMW|Rename single or multiple images
 [rename-tags](https://darktable-org.github.io/luadocs/lua.scripts.manual/scripts/contrib/rename-tags)|Yes|LMW|Change a tag name
 [RL_out_sharp](https://darktable-org.github.io/luadocs/lua.scripts.manual/scripts/contrib/rl_out_sharp)|No|LW|Output sharpening using GMic (Richardson-Lucy algorithm)
+[select_non_existing](https://darktable-org.github.io/luadocs/lua.scripts.manual/scripts/contrib/select_non_existing)|Yes|LMW|Enable selection of non-existing images in the the currently worked on images
 [select_untagged](https://darktable-org.github.io/luadocs/lua.scripts.manual/scripts/contrib/select_untagged)|Yes|LMW|Enable selection of untagged images
 [slideshowMusic](https://darktable-org.github.io/luadocs/lua.scripts.manual/scripts/contrib/slideshowMusic)|No|L|Play music during a slideshow
 [transfer_hierarchy](https://darktable-org.github.io/luadocs/lua.scripts.manual/scripts/contrib/transfer_hierarchy)|Yes|LMW|Image move/copy preserving directory hierarchy

--- a/contrib/select_non_existing.lua
+++ b/contrib/select_non_existing.lua
@@ -14,20 +14,26 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 --[[
-Enable selection of non existing images in the the currently worked on images, e.g. the ones selected by the collection module.
+Enable selection of non-existing images in the the currently worked on images, e.g. the ones selected by the collection module.
 ]]
 
 local dt = require "darktable"
 local du = require "lib/dtutils"
 local df = require "lib/dtutils.file"
 
-du.check_min_api_version("9.1.0", "select_non_existing") 
+-- module name
+local MODULE = "select_non_existing"
+
+du.check_min_api_version("9.1.0", MODULE)
+
+-- figure out the path separator
+local PS = dt.configuration.running_os == "windows" and  "\\"  or  "/"
 
 local gettext = dt.gettext
-gettext.bindtextdomain("select_non_existing", dt.configuration.config_dir.."/lua/locale/")
+gettext.bindtextdomain(MODULE, dt.configuration.config_dir..PS.."lua"..PS.."locale"..PS)
 
 local function _(msgid)
-    return gettext.dgettext("select_non_existing", msgid)
+    return gettext.dgettext(MODULE, msgid)
 end
 
 local function stop_job(job)
@@ -41,8 +47,9 @@ local function select_nonexisting_images(event, images)
     for key,image in ipairs(images) do
         if(job.valid) then
             job.percent = (key - 1)/#images
-            local filepath = image.path.."/"..image.filename
+            local filepath = image.path..PS..image.filename
             local file_exists = df.test_file(filepath, "e")
+            dt.print_log(filepath.." exists? => "..tostring(file_exists))
             if (not file_exists) then
                 table.insert(selection, image)
             end
@@ -56,14 +63,14 @@ local function select_nonexisting_images(event, images)
 end
 
 local function destroy()
-    dt.gui.libs.select.destroy_selection("select_non_existing")
+    dt.gui.libs.select.destroy_selection(MODULE)
 end
   
 dt.gui.libs.select.register_selection(
-    "select_non_existing",
+    MODULE,
     _("select non existing"),
     select_nonexisting_images,
-    _("select all non existing images in the the currently worked on images"))
+    _("select all non-existing images in the current images"))
 
 local script_data = {}
 script_data.destroy = destroy

--- a/contrib/select_non_existing.lua
+++ b/contrib/select_non_existing.lua
@@ -1,0 +1,70 @@
+--[[
+    This file is part of darktable,
+    copyright (c) 2023 Dirk Dittmar
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+]]
+--[[
+Enable selection of non existing images in the the currently worked on images, e.g. the ones selected by the collection module.
+]]
+
+local dt = require "darktable"
+local du = require "lib/dtutils"
+local df = require "lib/dtutils.file"
+
+du.check_min_api_version("9.1.0", "select_non_existing") 
+
+local gettext = dt.gettext
+gettext.bindtextdomain("select_non_existing", dt.configuration.config_dir.."/lua/locale/")
+
+local function _(msgid)
+    return gettext.dgettext("select_non_existing", msgid)
+end
+
+local function stop_job(job)
+    job.valid = false
+end
+
+local function select_nonexisting_images(event, images)
+    local selection = {}
+
+    local job = dt.gui.create_job(_("select non existing images"), true, stop_job)
+    for key,image in ipairs(images) do
+        if(job.valid) then
+            job.percent = (key - 1)/#images
+            local filepath = image.path.."/"..image.filename
+            local file_exists = df.test_file(filepath, "e")
+            if (not file_exists) then
+                table.insert(selection, image)
+            end
+        else
+            break
+        end
+    end    
+    stop_job(job)
+    
+    return selection
+end
+
+local function destroy()
+    dt.gui.libs.select.destroy_selection("select_non_existing")
+end
+  
+dt.gui.libs.select.register_selection(
+    "select_non_existing",
+    _("select non existing"),
+    select_nonexisting_images,
+    _("select all non existing images in the the currently worked on images"))
+
+local script_data = {}
+script_data.destroy = destroy
+return script_data

--- a/locale/de_DE/LC_MESSAGES/select_non_existing.po
+++ b/locale/de_DE/LC_MESSAGES/select_non_existing.po
@@ -1,27 +1,12 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: \n"
-"POT-Creation-Date: 2023-10-27 19:18+0200\n"
-"PO-Revision-Date: 2023-10-27 19:36+0200\n"
-"Last-Translator: Dirk Dittmar\n"
-"Language-Team: \n"
-"Language: de_DE\n"
-"MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.4.1\n"
-"X-Poedit-Basepath: ../../../contrib\n"
-"X-Poedit-SearchPath-0: select_non_existing.lua\n"
 
-#: select_non_existing.lua:40
 msgid "select non existing images"
 msgstr "nicht vorhandene Bilder auswählen"
 
-#: select_non_existing.lua:64
 msgid "select non existing"
 msgstr "nicht vorhandene auswählen"
 
-#: select_non_existing.lua:66
-msgid "select all non existing images in the the currently worked on images"
-msgstr "alle nicht vorhandenen Bilder in den aktuell Bildern auswählen"
+msgid "select all non-existing images in the current images"
+msgstr "alle nicht vorhandenen Bilder in den aktuellen Bildern auswählen"

--- a/locale/de_DE/LC_MESSAGES/select_non_existing.po
+++ b/locale/de_DE/LC_MESSAGES/select_non_existing.po
@@ -1,0 +1,27 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: 2023-10-27 19:18+0200\n"
+"PO-Revision-Date: 2023-10-27 19:36+0200\n"
+"Last-Translator: Dirk Dittmar\n"
+"Language-Team: \n"
+"Language: de_DE\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.4.1\n"
+"X-Poedit-Basepath: ../../../contrib\n"
+"X-Poedit-SearchPath-0: select_non_existing.lua\n"
+
+#: select_non_existing.lua:40
+msgid "select non existing images"
+msgstr "nicht vorhandene Bilder auswählen"
+
+#: select_non_existing.lua:64
+msgid "select non existing"
+msgstr "nicht vorhandene auswählen"
+
+#: select_non_existing.lua:66
+msgid "select all non existing images in the the currently worked on images"
+msgstr "alle nicht vorhandenen Bilder in den aktuell Bildern auswählen"


### PR DESCRIPTION
A script to select all images that do not exist anymore.

It helps (at least me) to select all images and remove them. This way a user don't have to call `purge_non_existing_images.sh` to clean the collection.