### PR TITLE
select non-existing images

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ change_group_leader|Yes|LMW|Change which image leads group
 [rename_images](https://darktable-org.github.io/luadocs/lua.scripts.manual/scripts/contrib/rename_images)|Yes|LMW|Rename single or multiple images
 [rename-tags](https://darktable-org.github.io/luadocs/lua.scripts.manual/scripts/contrib/rename-tags)|Yes|LMW|Change a tag name
 [RL_out_sharp](https://darktable-org.github.io/luadocs/lua.scripts.manual/scripts/contrib/rl_out_sharp)|No|LW|Output sharpening using GMic (Richardson-Lucy algorithm)
+[select_non_existing](https://darktable-org.github.io/luadocs/lua.scripts.manual/scripts/contrib/select_non_existing)|Yes|LMW|Enable selection of non-existing images in the the currently worked on images
 [select_untagged](https://darktable-org.github.io/luadocs/lua.scripts.manual/scripts/contrib/select_untagged)|Yes|LMW|Enable selection of untagged images
 [slideshowMusic](https://darktable-org.github.io/luadocs/lua.scripts.manual/scripts/contrib/slideshowMusic)|No|L|Play music during a slideshow
 [transfer_hierarchy](https://darktable-org.github.io/luadocs/lua.scripts.manual/scripts/contrib/transfer_hierarchy)|Yes|LMW|Image move/copy preserving directory hierarchy

--- a/contrib/select_non_existing.lua
+++ b/contrib/select_non_existing.lua
@@ -1,0 +1,77 @@
+--[[
+    This file is part of darktable,
+    copyright (c) 2023 Dirk Dittmar
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+]]
+--[[
+Enable selection of non-existing images in the the currently worked on images, e.g. the ones selected by the collection module.
+]]
+
+local dt = require "darktable"
+local du = require "lib/dtutils"
+local df = require "lib/dtutils.file"
+
+-- module name
+local MODULE = "select_non_existing"
+
+du.check_min_api_version("9.1.0", MODULE)
+
+-- figure out the path separator
+local PS = dt.configuration.running_os == "windows" and  "\\"  or  "/"
+
+local gettext = dt.gettext
+gettext.bindtextdomain(MODULE, dt.configuration.config_dir..PS.."lua"..PS.."locale"..PS)
+
+local function _(msgid)
+    return gettext.dgettext(MODULE, msgid)
+end
+
+local function stop_job(job)
+    job.valid = false
+end
+
+local function select_nonexisting_images(event, images)
+    local selection = {}
+
+    local job = dt.gui.create_job(_("select non existing images"), true, stop_job)
+    for key,image in ipairs(images) do
+        if(job.valid) then
+            job.percent = (key - 1)/#images
+            local filepath = image.path..PS..image.filename
+            local file_exists = df.test_file(filepath, "e")
+            dt.print_log(filepath.." exists? => "..tostring(file_exists))
+            if (not file_exists) then
+                table.insert(selection, image)
+            end
+        else
+            break
+        end
+    end    
+    stop_job(job)
+    
+    return selection
+end
+
+local function destroy()
+    dt.gui.libs.select.destroy_selection(MODULE)
+end
+  
+dt.gui.libs.select.register_selection(
+    MODULE,
+    _("select non existing"),
+    select_nonexisting_images,
+    _("select all non-existing images in the current images"))
+
+local script_data = {}
+script_data.destroy = destroy
+return script_data

--- a/locale/de_DE/LC_MESSAGES/select_non_existing.po
+++ b/locale/de_DE/LC_MESSAGES/select_non_existing.po
@@ -1,0 +1,12 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+
+msgid "select non existing images"
+msgstr "nicht vorhandene Bilder auswählen"
+
+msgid "select non existing"
+msgstr "nicht vorhandene auswählen"
+
+msgid "select all non-existing images in the current images"
+msgstr "alle nicht vorhandenen Bilder in den aktuellen Bildern auswählen"


### PR DESCRIPTION
Enable selection of non-existing images in the the currently worked on images

This script helps (at least me) to select images that don't exist anymore. This way there is no need to call `purge_non_existing_images.sh`.