### PR TITLE
Update x-touch.lua with support for primaries slider

### DIFF
--- a/examples/x-touch.lua
+++ b/examples/x-touch.lua
@@ -96,7 +96,20 @@ for k = 1,8 do
                     "purple",
                     "magenta" }
         element = e[k]
+                
+                
+      -- if the sigmoid rgb primaries is focused, 
+      -- check sliders
+      elseif dt.gui.action("iop/sigmoid", "focus") ~= 0 and k <8 then
+        local e = { "red attenuation", "red rotation", "green attenuation", "green rotation", "blue attenuation", "blue rotation", "recover purity" }
+        which = "iop/sigmoid/primaries/"..e[k]
 
+      -- if the rgb primaries is focused, 
+      -- check sliders
+      elseif dt.gui.action("iop/primaries", "focus") ~= 0 and k >=1 then
+        local e = { "red hue", "red purity", "green hue", "green purity", "blue hue", "blue purity", "tint hue", "tint purity" }
+        which = "iop/primaries/" ..e[k]
+      
       -- if the tone equalizer is focused, 
       -- select one of the sliders in the "simple" tab
       elseif dt.gui.action("iop/toneequal", "focus") ~= 0 then

--- a/examples/x-touch.lua
+++ b/examples/x-touch.lua
@@ -53,7 +53,7 @@ midi:C0=iop/channelmixerrgb;focus
 local dt = require "darktable"
 local du = require "lib/dtutils"
 
-du.check_min_api_version("9.1.0", "x-touch")
+du.check_min_api_version("9.2.0", "x-touch")
 
 -- set up 8 mimic sliders with the same function
 for k = 1,8 do


### PR DESCRIPTION
maps knobs to the primaries sliders
requires darktable 4.6.x