### PR TITLE
POC: translation done by darktable.

### DIFF
--- a/official/copy_paste_metadata.lua
+++ b/official/copy_paste_metadata.lua
@@ -58,11 +58,8 @@ local publisher = ""
 local rights = ""
 local tags = {}
 
--- Tell gettext where to find the .mo file translating messages for a particular domain
-gettext.bindtextdomain("copy_paste_metadata",dt.configuration.config_dir.."/lua/locale/")
-
 local function _(msgid)
-    return gettext.dgettext("copy_paste_metadata", msgid)
+    return gettext.gettext(msgid)
 end
 
 local function copy(image)

--- a/tools/script_manager.lua
+++ b/tools/script_manager.lua
@@ -59,11 +59,8 @@ local debug = require "darktable.debug"
 local gettext = dt.gettext
 
 
--- Tell gettext where to find the .mo file translating messages for a particular domain
-gettext.bindtextdomain("script_manager",dt.configuration.config_dir.."/lua/locale/")
-
 local function _(msgid)
-    return gettext.dgettext("script_manager", msgid)
+    return gettext.gettext(msgid)
 end
 
 -- api check


### PR DESCRIPTION
This is a POC on how Lua script translation could be handled directly in darktable.

### The darktable part

- Add lua-scripts has a submodule in src/external

- Add all lua files into `po/POTFILES.in`

This will make it possible with the current main darktable translation workflow to also translate the scripts.

 ### The Lua script part

- As proposed in this PR remove the gettext domain, use a common one to share as much as possible the strings across darktable and all lua scripts.

- Use common casing for all Lua strings. Indeed there is some string identical except for the casing. Again this is to share a maximum of string.

- Remove any spaces in start or end of strings, the layout must not be done in strings. I see for example `"of "` and some other cases.

### Redesign

- As discussed in issue #438 we also want to redesign the Lua script description to be more uniform and structured. Those description must be done using `_('...")` to allow for translation. Some description are quite big, I'm wondering if we want this in the dt tooltip or maybe a lite description in dt tooltip and a full description in main dt documentation. To be discussed.

- We probably want to have a string for the name of the module provided by the script. As I understand we use the script filename for the name today. This is not really user friendly, so better have a string for the name of the script which is displayed on the UI (as done for dt modules).

- The redesigned of the UI with standard button as already discussed.

@wpferguson : This is my current idea to make Lua scripts a first class citizen. Let me know how it sounds to you.

I hope I have not missed something, but at least with this POC I was able to translate Lua scripts in French.