### PR TITLE
tools/script_manager - fixed crash

### DIFF
--- a/tools/script_manager.lua
+++ b/tools/script_manager.lua
@@ -497,14 +497,15 @@ local function process_script_data(script_file)
 
   -- add the script data
   local category,path,name,filename,filetype = string.match(script_file, pattern)
-  log.msg(log.debug, "category is " .. category)
-  log.msg(log.debug, "name is " .. name)
 
-  add_script_category(category)
+  if category and name and path then
+    log.msg(log.debug, "category is " .. category)
+    log.msg(log.debug, "name is " .. name)
 
-  if name then
+    add_script_category(category)
     add_script_name(name, path, category)
   end
+
   restore_log_level(old_log_level)
 end
 


### PR DESCRIPTION
The script manager crashes if a LUA script was not copied to a subfolder but directly into the LUA directory. The reason is that the regular expression, which among other things extracts the category of the script from its file path, does not match and thus the category is null. To prevent this, a null check has been added.