### PR TITLE
script_manager - support libraries in "local" directories

### DIFF
--- a/tools/script_manager.lua
+++ b/tools/script_manager.lua
@@ -509,6 +509,25 @@ local function process_script_data(script_file)
   restore_log_level(old_log_level)
 end
 
+local function ensure_lib_in_search_path(line)
+  local old_log_level = set_log_level(sm.log_level)
+  set_log_level(log.debug)
+  log.msg(log.debug, "line is " .. line)
+  if string.match(line, ds.sanitize_lua(dt.configuration.config_dir .. PS .. "lua/lib")) then
+    log.msg(log.debug, line .. " is already in search path, returning...")
+    return
+  end
+  local path = string.match(line, "(.+)/lib/.+lua")
+  log.msg(log.debug, "extracted path is " .. path)
+  log.msg(log.debug, "package.path is " .. package.path)
+  if not string.match(package.path, ds.sanitize_lua(path)) then
+    log.msg(log.debug, "path isn't in package.path, adding...")
+    package.path = package.path .. ";" .. path .. "/?.lua"
+    log.msg(log.debug, "new package.path is " .. package.path)
+  end
+  restore_log_level(old_log_level)
+end
+
 local function scan_scripts(script_dir)
   local old_log_level = set_log_level(sm.log_level)
   local script_count = 0
@@ -529,6 +548,8 @@ local function scan_scripts(script_dir)
             process_script_data(script_file)
             script_count = script_count + 1
           end
+        else
+          ensure_lib_in_search_path(line)                             -- but let's make sure libraries can be found
         end
       end
     end


### PR DESCRIPTION
Add support for "local" libraries specific to a script or set of scripts.  Currently only the `lua/lib` is searched for libraries.  

This change adds a check for each `.lua` file in a `lib` directory and adds an entry to the `package.path` search path if necessary.  Then entry is added to the end of that search path entries, so if the library name is the same as an existing one earlier in the search path, the earlier one will be used.