### PR TITLE
lib/dtutils/system - fixed typo in quote_windows_command call

### DIFF
--- a/lib/dtutils/system.lua
+++ b/lib/dtutils/system.lua
@@ -91,7 +91,7 @@ function dtutils_system.windows_command(command)
   if file then
     dt.print_log("opened file")
     command = string.gsub(command, "%%", "%%%%") -- escape % from windows shell
-    command = quote_windows-command(command)
+    command = quote_windows_command(command)
     file:write(command)
     file:close()
 


### PR DESCRIPTION
changed `quote_windows-command` call to the correct `quote_windows_command`

Fixes https://github.com/darktable-org/darktable/issues/17108