### PR TITLE
Desanitize libs

### DIFF
--- a/contrib/autostyle.lua
+++ b/contrib/autostyle.lua
@@ -69,7 +69,7 @@ script_data.show = nil -- only required for libs since the destroy_method only h
 -- run command and retrieve stdout
 local function get_stdout(cmd)
   -- Open the command, for reading
-  local fd = assert(syslib.io_popen(cmd, 'r'))
+  local fd = assert(io.popen(cmd, 'r'))
   darktable.control.read(fd)
   -- slurp the whole file
   local data = assert(fd:read('*a'))

--- a/contrib/color_profile_manager.lua
+++ b/contrib/color_profile_manager.lua
@@ -107,7 +107,7 @@ end
 
 local function list_profiles(dir)
   local files = {}
-  local p = dtsys.io_popen(DIR_CMD .. " " .. dir)
+  local p = io.popen(DIR_CMD .. " " .. dir)
   if p then
     for line in p:lines() do
       table.insert(files, line)

--- a/contrib/fujifilm_dynamic_range.lua
+++ b/contrib/fujifilm_dynamic_range.lua
@@ -106,7 +106,7 @@ local function detect_dynamic_range(event, image)
 	-- without -n flag, exiftool will round to the nearest tenth
 	command = command .. " -RawExposureBias -n -t " .. RAF_filename
 	dt.print_log(command)
-	output = dtsys.io_popen(command)
+	output = io.popen(command)
 	local raf_result = output:read("*all")
 	output:close()
 	if #raf_result == 0 then

--- a/contrib/fujifilm_ratings.lua
+++ b/contrib/fujifilm_ratings.lua
@@ -65,7 +65,7 @@ local function detect_rating(event, image)
 	local JPEG_filename = string.gsub(RAF_filename, "%.RAF$", ".JPG")
 	local command = "exiftool -Rating " .. JPEG_filename
 	dt.print_log(command)
-	local output = dtsys.io_popen(command)
+	local output = io.popen(command)
 	local jpeg_result = output:read("*all")
 	output:close()
 	if string.len(jpeg_result) > 0 then
@@ -76,7 +76,7 @@ local function detect_rating(event, image)
 	end
 	command = "exiftool -Rating " .. RAF_filename
 	dt.print_log(command)
-	output = dtsys.io_popen(command)
+	output = io.popen(command)
 	local raf_result = output:read("*all")
 	output:close()
 	if string.len(raf_result) > 0 then

--- a/contrib/geoJSON_export.lua
+++ b/contrib/geoJSON_export.lua
@@ -331,7 +331,7 @@ dt.preferences.register("geoJSON_export",
 	_("opens the geoJSON file after the export with the standard program for geoJSON files"),
 	false )
 
-local handle = dtsys.io_popen("xdg-user-dir DESKTOP")
+local handle = io.popen("xdg-user-dir DESKTOP")
 local result = handle:read()
 handle:close()
 if (result == nil) then

--- a/contrib/geoToolbox.lua
+++ b/contrib/geoToolbox.lua
@@ -412,7 +412,7 @@ local function reverse_geocode()
     -- jq could be replaced with a Lua JSON parser
     startCommand = string.format("curl --silent \"https://api.mapbox.com/geocoding/v5/mapbox.places/%s,%s.json?types=%s&access_token=%s\" | jq '.features | .[0] | '.text''", lon1, lat1, types, tokan)
 
-    local handle = dtsys.io_popen(startCommand)
+    local handle = io.popen(startCommand)
     local result = trim12(handle:read("*a"))
     handle:close()
     

--- a/contrib/image_stack.lua
+++ b/contrib/image_stack.lua
@@ -348,7 +348,7 @@ local function list_files(search_string)
     search_string = string.gsub(search_string, "/", "\\\\")
   end
 
-  local f = dtsys.io_popen(ls .. search_string)
+  local f = io.popen(ls .. search_string)
   if f then
     local found_file = f:read()
     while found_file do 

--- a/contrib/image_time.lua
+++ b/contrib/image_time.lua
@@ -226,7 +226,7 @@ local function get_image_taken_time(image)
 
   local exiv2 = df.check_if_bin_exists("exiv2")
   if exiv2 then
-    p = dtsys.io_popen(exiv2 .. " -K Exif.Image.DateTime " .. image.path .. PS .. image.filename)
+    p = io.popen(exiv2 .. " -K Exif.Image.DateTime " .. image.path .. PS .. image.filename)
     if p then
       for line in p:lines() do
         if string.match(line, "Exif.Image.DateTime") then
@@ -244,7 +244,7 @@ end
 
 local function _get_windows_image_file_creation_time(image)
   local datetime = nil
-  local p = dtsys.io_popen("dir " .. image.path .. PS .. image.filename)
+  local p = io.popen("dir " .. image.path .. PS .. image.filename)
   if p then
     for line in p:lines() do
       if string.match(line, ds.sanitize_lua(image.filename)) then
@@ -265,7 +265,7 @@ end
 
 local function _get_nix_image_file_creation_time(image)
   local datetime = nil
-  local p = dtsys.io_popen("ls -lL --time-style=full-iso " .. image.path .. PS .. image.filename)
+  local p = io.popen("ls -lL --time-style=full-iso " .. image.path .. PS .. image.filename)
   if p then
     for line in p:lines() do
       if string.match(line, ds.sanitize_lua(image.filename)) then

--- a/contrib/kml_export.lua
+++ b/contrib/kml_export.lua
@@ -343,7 +343,7 @@ if dt.configuration.running_os == "windows" then
 elseif dt.configuration.running_os == "macos" then
   defaultDir =  os.getenv("HOME")
 else
-  local handle = dsys.io_popen("xdg-user-dir DESKTOP")
+  local handle = io.popen("xdg-user-dir DESKTOP")
   defaultDir = handle:read()
   handle:close()
 end

--- a/lib/dtutils/file.lua
+++ b/lib/dtutils/file.lua
@@ -42,7 +42,7 @@ end
 
 local function _win_os_execute(cmd)
   local result = nil
-  local p = dsys.io_popen(cmd)
+  local p = io.popen(cmd)
   local output = p:read("*a")
   p:close()
   if string.match(output, "true") then 
@@ -94,7 +94,7 @@ dtutils_file.libdoc.functions["test_file"] = {
 
 function dtutils_file.test_file(path, test)
   local cmd = "test -"
-  local engine = dsys.os_execute
+  local engine = os.execute
   local cmdstring = ""
 
   if dt.configuration.running_os == "windows" then
@@ -167,7 +167,7 @@ local function _search_for_bin_windows(bin)
 
   for _,arg in ipairs(args) do
     local cmd = "where " .. arg .. " " .. ds.sanitize(bin)
-    local p = dsys.io_popen(cmd)
+    local p = io.popen(cmd)
     local output = p:read("*a")
     p:close()
     local lines = du.split(output, "\n")
@@ -191,7 +191,7 @@ end
 
 local function _search_for_bin_nix(bin)
   local result = false
-  local p = dsys.io_popen("command -v " .. bin)
+  local p = io.popen("command -v " .. bin)
   local output = p:read("*a")
   p:close()
   if string.len(output) > 0 then
@@ -220,7 +220,7 @@ local function _search_for_bin_macos(bin)
       search_start = "/Applications/" .. bin .. ".app"
     end
 
-    local p = dsys.io_popen("find " .. search_start .. " -type f -name " .. bin .. " -print")
+    local p = io.popen("find " .. search_start .. " -type f -name " .. bin .. " -print")
     local output = p:read("*a")
     p:close()
     local lines = du.split(output, "\n")
@@ -445,7 +445,7 @@ function dtutils_file.check_if_file_exists(filepath)
   local result = false
   if (dt.configuration.running_os == 'windows') then
     filepath = string.gsub(filepath, '[\\/]+', '\\')
-    local p = dsys.io_popen("if exist " .. dtutils_file.sanitize_filename(filepath) .. " (echo 'yes') else (echo 'no')")
+    local p = io.popen("if exist " .. dtutils_file.sanitize_filename(filepath) .. " (echo 'yes') else (echo 'no')")
     local ans = p:read("*all")
     p:close()
     if string.match(ans, "yes") then
@@ -456,7 +456,7 @@ function dtutils_file.check_if_file_exists(filepath)
 --     result = false
 --    end
   elseif (dt.configuration.running_os == "linux") then
-    result = dsys.os_execute('test -e ' .. dtutils_file.sanitize_filename(filepath))
+    result = os.execute('test -e ' .. dtutils_file.sanitize_filename(filepath))
     if not result then
       result = false
     end
@@ -522,9 +522,9 @@ function dtutils_file.file_copy(fromFile, toFile)
   local result = nil
   -- if cp exists, use it
   if dt.configuration.running_os == "windows" then
-    result = dsys.os_execute('copy "' .. fromFile .. '" "' .. toFile .. '"')
+    result = os.execute('copy "' .. fromFile .. '" "' .. toFile .. '"')
   elseif dtutils_file.check_if_bin_exists("cp") then
-    result = dsys.os_execute("cp '" .. fromFile .. "' '" .. toFile .. "'")
+    result = os.execute("cp '" .. fromFile .. "' '" .. toFile .. "'")
   end
 
   -- if cp was not present, or if cp failed, then a pure lua solution
@@ -575,7 +575,7 @@ function dtutils_file.file_move(fromFile, toFile)
   if not success then
     -- an error occurred, so let's try using the operating system function
     if dtutils_file.check_if_bin_exists("mv") then
-      success = dsys.os_execute("mv '" .. fromFile .. "' '" .. toFile .. "'")
+      success = os.execute("mv '" .. fromFile .. "' '" .. toFile .. "'")
     end
     -- if the mv didn't exist or succeed, then...
     if not success then

--- a/lib/dtutils/string.lua
+++ b/lib/dtutils/string.lua
@@ -298,16 +298,32 @@ local function _sanitize_windows(str)
   end
 end
 
+local function _should_be_sanitized(str)
+  local old_log_level = log.log_level()
+  local result = false
+  log.log_level(dtutils_string.log_level)
+  if string.match(str, "[^%g]") then
+    result =  true
+  end
+  log.log_level(old_log_level)
+  return result
+end
+
 function dtutils_string.sanitize(str)
   local old_log_level = log.log_level()
+  local sanitized_str = nil
   log.log_level(dtutils_string.log_level)
-  if dt.configuration.running_os == "windows" then
-    log.log_level(old_log_level)
-    return _sanitize_windows(str)
+  if _should_be_sanitized(str) then
+    if dt.configuration.running_os == "windows" then
+      sanitized_str = _sanitize_windows(str)
+    else
+      sanitized_str = _sanitize_posix(str)
+    end
   else
-    log.log_level(old_log_level)
-    return _sanitize_posix(str)
+    sanitized_str = str
   end
+  log.log_level(old_log_level)
+  return sanitized_str
 end
 
 dtutils_string.libdoc.functions["sanitize_lua"] = {

--- a/lib/dtutils/system.lua
+++ b/lib/dtutils/system.lua
@@ -51,7 +51,7 @@ function dtutils_system.external_command(command)
   local result = nil
 
   if dt.configuration.running_os == "windows" then
-    result = dtutils_system.windows_command(ds.sanitize(command))
+    result = dtutils_system.windows_command(command)
   else
     result = dt.control.execute(command)
   end
@@ -78,20 +78,20 @@ dtutils_system.libdoc.functions["windows_command"] = {
   Copyright = [[]],
 }
 
-local function quote_windows_command(command)
+local function _quote_windows_command(command)
   return "\"" .. command .. "\""
 end
 
 function dtutils_system.windows_command(command)
   local result = 1
 
-  local fname = ds.sanitize(dt.configuration.tmp_dir .. "/run_command.bat")
+  local fname = dt.configuration.tmp_dir .. "/run_command.bat"
 
   local file = io.open(fname, "w")
   if file then
     dt.print_log("opened file")
     command = string.gsub(command, "%%", "%%%%") -- escape % from windows shell
-    command = quote_windows_command(command)
+    command = _quote_windows_command(command)
     file:write(command)
     file:close()
 
@@ -124,6 +124,7 @@ dtutils_system.libdoc.functions["launch_default_app"] = {
   License = [[]],
   Copyright = [[]],
 }
+
 function dtutils_system.launch_default_app(path) 
   local open_cmd = "xdg-open "
   if (dt.configuration.running_os == "windows") then
@@ -133,57 +134,5 @@ function dtutils_system.launch_default_app(path)
   end   
   return dtutils_system.external_command(open_cmd .. path)
 end
-
-
-dtutils_system.libdoc.functions["os_execute"] = {
-  Name = [[os_execute]],
-  Synopsis = [[wrapper around the lua os.execute function]],
-  Usage = [[local dsys = require "lib/dtutils.file"
-
-    result = dsys.os_execute(cmd)
-      cmd - string - a command to execute on the operating system]],
-  Description = [[os_execute wraps the lua os.execute system call to provide
-    correct sanitization of windows commands]],
-  Return_Value = [[see the lua os.execute documentation]],
-  Limitations = [[]],
-  Example = [[]],
-  See_Also = [[]],
-  Reference = [[]],
-  License = [[]],
-  Copyright = [[]],
-}
-
-function dtutils_system.os_execute(cmd)
-  if dt.configuration.running_os == "windows" then
-    cmd = quote_windows_command(cmd)
-  end
-  return os.execute(cmd)
-end
-
-dtutils_system.libdoc.functions["io_popen"] = {
-  Name = [[io_popen]],
-  Synopsis = [[wrapper around the lua io.popen function]],
-  Usage = [[local dsys = require "lib/dtutils.file"
-
-    result = dsys.io_popen(cmd)
-      cmd - string - a command to execute and attach to]],
-  Description = [[io_popen wraps the lua io.popen system call to provide
-    correct sanitization of windows commands]],
-  Return_Value = [[see the lua io.popen documentation]],
-  Limitations = [[]],
-  Example = [[]],
-  See_Also = [[]],
-  Reference = [[]],
-  License = [[]],
-  Copyright = [[]],
-}
-
-function dtutils_system.io_popen(cmd)
-  if dt.configuration.running_os == "windows" then
-    cmd = quote_windows_command(cmd)
-  end
-  return io.popen(cmd)
-end
-
 
 return dtutils_system

--- a/official/enfuse.lua
+++ b/official/enfuse.lua
@@ -116,7 +116,7 @@ if enfuse_installed then
 
   local version = nil
 
-  local p = dtsys.io_popen(enfuse_installed .. " --version")
+  local p = io.popen(enfuse_installed .. " --version")
   local f = p:read("all")
   p:close()
   version = string.match(f, "enfuse (%d.%d)")

--- a/tools/executable_manager.lua
+++ b/tools/executable_manager.lua
@@ -76,7 +76,7 @@ local function grep(file, pattern)
   if dt.configuration.running_os == "windows" then
     -- use find to get the matches
     local command = "\\windows\\system32\\find.exe " .. "\"" .. pattern .. "\"" .. " " .. file
-    local f = dtsys.io_popen(command)
+    local f = io.popen(command)
     local output = f:read("all")
     f:close()
     -- strip out the first line
@@ -85,7 +85,7 @@ local function grep(file, pattern)
   else
     -- use grep and just return the answers
     local command = "grep " .. pattern .. " " .. file
-    local f = dtsys.io_popen(command)
+    local f = io.popen(command)
     local output = f:read("all")
     f:close()
     result = du.split(output, "\n")

--- a/tools/get_lib_manpages.lua
+++ b/tools/get_lib_manpages.lua
@@ -46,7 +46,7 @@ local function output_man(d)
     mf:close()
     if df.check_if_bin_exists("groff") then
       if df.check_if_bin_exists("ps2pdf") then
-        dtsys.os_execute("groff -man " .. fname .. " | ps2pdf - " .. fname .. ".pdf")
+        os.execute("groff -man " .. fname .. " | ps2pdf - " .. fname .. ".pdf")
       else
         log.msg(log.error, "Missing ps2pdf.  Can't generate pdf man pages.")
       end
@@ -60,7 +60,7 @@ end
 
 -- find the libraries
 
-local output = dtsys.io_popen("cd "..dt.configuration.config_dir.."/lua/lib ;find . -name \\*.lua -print | sort")
+local output = io.popen("cd "..dt.configuration.config_dir.."/lua/lib ;find . -name \\*.lua -print | sort")
 
 -- loop through the libraries
 

--- a/tools/get_libdoc.lua
+++ b/tools/get_libdoc.lua
@@ -37,7 +37,7 @@ end
 
 -- find the libraries
 
-local output = dtsys.io_popen("cd "..dt.configuration.config_dir.."/lua/lib ;find . -name \\*.lua -print | sort")
+local output = io.popen("cd "..dt.configuration.config_dir.."/lua/lib ;find . -name \\*.lua -print | sort")
 
 -- loop through the libraries
 

--- a/tools/script_manager.lua
+++ b/tools/script_manager.lua
@@ -89,7 +89,7 @@ local MIN_BUTTONS_PER_PAGE <const> = 5
 local MAX_BUTTONS_PER_PAGE <const> = 20
 local DEFAULT_BUTTONS_PER_PAGE <const> = 10
 
-local DEFAULT_LOG_LEVEL <const> = log.error
+local DEFAULT_LOG_LEVEL <const> = log.debug
 
 local LUA_DIR <const> = dt.configuration.config_dir .. PS .. "lua"
 local LUA_SCRIPT_REPO <const> = "https://github.com/darktable-org/lua-scripts.git"
@@ -244,7 +244,7 @@ end
 local function get_repo_status(repo)
   local old_log_level = set_log_level(sm.log_level)
 
-  local p = dtsys.io_popen("cd " .. repo .. CS .. "git status")
+  local p = io.popen("cd " .. repo .. CS .. "git status")
 
   if p then
     local data = p:read("*a")
@@ -262,7 +262,7 @@ local function get_current_repo_branch(repo)
 
   local branch = nil
 
-  local p = dtsys.io_popen("cd " .. repo .. CS .. "git branch --all")
+  local p = io.popen("cd " .. repo .. CS .. "git branch --all")
 
   if p then
     local data = p:read("*a")
@@ -292,7 +292,7 @@ local function get_repo_branches(repo)
   local old_log_level = set_log_level(sm.log_level)
 
   local branches = {}
-  local p = dtsys.io_popen("cd " .. repo .. CS .. "git pull --all" .. CS .. "git branch --all")
+  local p = io.popen("cd " .. repo .. CS .. "git pull --all" .. CS .. "git branch --all")
 
   if p then
     local data = p:read("*a")
@@ -332,7 +332,7 @@ local function checkout_repo_branch(repo, branch)
 
   log.msg(log.info, "checkout out branch " .. branch .. " from repository " .. repo)
 
-  dtsys.os_execute("cd " .. repo .. CS .. "git checkout " .. branch)
+  os.execute("cd " .. repo .. CS .. "git checkout " .. branch)
 
   restore_log_level(old_log_level)
 end
@@ -668,7 +668,7 @@ local function scan_scripts(script_dir)
   log.msg(log.debug, "find command is " .. find_cmd)
 
   -- scan the scripts
-  local output = dtsys.io_popen(find_cmd)
+  local output = io.popen(find_cmd)
   for line in output:lines() do
     log.msg(log.debug, "line is " .. line)
     local l = string.gsub(line, ds.sanitize_lua(LUA_DIR) .. PS, "")   -- strip the lua dir off
@@ -754,7 +754,7 @@ local function scan_repositories()
 
   log.msg(log.debug, "find command is " .. find_cmd)
 
-  local output = dtsys.io_popen(find_cmd)
+  local output = io.popen(find_cmd)
 
   for line in output:lines() do
     local l = string.gsub(line, ds.sanitize_lua(LUA_DIR) .. PS, "")   -- strip the lua dir off


### PR DESCRIPTION
Reverted the io_popen and os_execute wrappers added to system library.  Removed quote windows command.

Added a check to see if sanitizing the input string is necessary to get rid of needless sanitization of strings that led to other problems on windows.

Tested on Linux and windows with spaces in the command paths and the image paths.

Fixes #492 