### PR TITLE
tools/script_manager - restore script_manager_running_script

### DIFF
--- a/tools/script_manager.lua
+++ b/tools/script_manager.lua
@@ -517,6 +517,7 @@ local function activate(script)
     status = true
     pref_write(script.script_name, "bool", true)
   end
+  script_manager_running_script = "script_manager"
 
   restore_log_level(old_log_level)
   return status


### PR DESCRIPTION
restore script_manager_running_script to  "script_manager" after changing it to start a script