### PR TITLE
updated tools/*.lua messages for translation

### DIFF
--- a/tools/executable_manager.lua
+++ b/tools/executable_manager.lua
@@ -37,8 +37,6 @@ du.check_min_api_version("7.0.0", "executable_manager")
 
 local gettext = dt.gettext.gettext
 
-dt.gettext.bindtextdomain("executable_manager", dt.configuration.config_dir .."/lua/locale/")
-
 local function _(msg)
     return gettext(msg)
 end
@@ -117,7 +115,7 @@ local function install_module()
   if not exec_man.module_installed then
     dt.register_lib(
       "executable_manager",     -- Module name
-      "executable manager",     -- Visible name
+      _("executables"),     -- Visible name
       true,                -- expandable
       false,               -- resetable
       {[dt.gui.views.lighttable] = {panel, panel_pos}},   -- containers
@@ -201,7 +199,7 @@ exec_man.stack = dt.new_widget("stack"){}
 -- create a combobox to for indexing into the stack of widgets
 
 exec_man.selector = dt.new_widget("combobox"){
-  label = "executable",
+  label = _("executable"),
   tooltip = _("select executable to modify"),
   value = 1, "placeholder",
   changed_callback = function(self)

--- a/tools/get_lib_manpages.lua
+++ b/tools/get_lib_manpages.lua
@@ -15,8 +15,6 @@ du.check_min_api_version("3.0.0", "get_lib_manpages")
 
 local gettext = dt.gettext.gettext
 
-dt.gettext.bindtextdomain("get_lib_manpages", dt.configuration.config_dir .."/lua/locale/")
-
 local function _(msg)
     return gettext(msg)
 end

--- a/tools/get_libdoc.lua
+++ b/tools/get_libdoc.lua
@@ -12,8 +12,6 @@ du.check_min_api_version("3.0.0", "get_libdoc")
 
 local gettext = dt.gettext.gettext
 
-dt.gettext.bindtextdomain("get_libdoc", dt.configuration.config_dir .."/lua/locale/")
-
 local function _(msg)
     return gettext(msg)
 end

--- a/tools/script_manager.lua
+++ b/tools/script_manager.lua
@@ -58,10 +58,6 @@ local debug = require "darktable.debug"
 
 local gettext = dt.gettext
 
-
--- Tell gettext where to find the .mo file translating messages for a particular domain
-dt.gettext.bindtextdomain("script_manager", dt.configuration.config_dir .. "/lua/locale/")
-
 local function _(msgid)
     return gettext.dgettext("script_manager", msgid)
 end
@@ -469,7 +465,7 @@ local function get_script_doc(script)
     return description
   else
     restore_log_level(old_log_level)
-    return "No documentation available"
+    return _("No documentation available")
   end
 end
 
@@ -835,7 +831,7 @@ local function install_scripts()
 
     if count > 0 then
       update_combobox_choices(sm.widgets.folder_selector, sm.folders, sm.widgets.folder_selector.selected)
-      dt.print(_("scripts successfully installed into folder ") .. folder)
+      dt.print(_(string.format("scripts successfully installed into folder %s"), folder))
       table.insert(sm.installed_repositories, {name = folder, directory = LUA_DIR .. PS .. folder})
       update_script_update_choices()
 
@@ -1165,7 +1161,7 @@ local function install_module()
   if not sm.module_installed then
     dt.register_lib(
       "script_manager",     -- Module name
-      "script manager",     -- Visible name
+      _("scripts"),     -- Visible name
       true,                -- expandable
       false,               -- resetable
       {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_LEFT_BOTTOM", 100}},   -- containers
@@ -1408,7 +1404,7 @@ end
 local page_back = "<"
 local page_forward = ">"
 
-sm.widgets.page_status = dt.new_widget("label"){label = _("page:")}
+sm.widgets.page_status = dt.new_widget("label"){label = _("page") .. ":"}
 
 sm.widgets.page_back = dt.new_widget("button"){
   label = page_back,

--- a/tools/script_manager.lua
+++ b/tools/script_manager.lua
@@ -465,7 +465,7 @@ local function get_script_doc(script)
     return description
   else
     restore_log_level(old_log_level)
-    return _("No documentation available")
+    return _("no documentation available")
   end
 end
 


### PR DESCRIPTION
Cleaned up translatable messages in the tools.

Changed `executable_manager` displayed name to `executables`.

Changed `script_manager` displayed name to `scripts`.

@TurboGit please take a look.  Thanks