### PR TITLE
Make strings translation safe

### DIFF
--- a/contrib/hif_group_leader.lua
+++ b/contrib/hif_group_leader.lua
@@ -186,7 +186,7 @@ dt.register_event(MODULE .. "_collect", "shortcut",
     local images = dt.collection
     make_existing_hif_group_leader(images)
   end,
-  string.format(_("make hif group leader for %s", _("collection")))
+  _("make hif group leader for collection")
 )
 
 dt.register_event(MODULE .. "_select", "shortcut",
@@ -194,7 +194,7 @@ dt.register_event(MODULE .. "_select", "shortcut",
     local images = dt.gui.selection()
     make_existing_hif_group_leader(images)
   end,
-  string.format(_("make hif group leader for %s", _("selection")))
+  _("make hif group leader for selection")
 )
 
 return script_data

--- a/contrib/jpg_group_leader.lua
+++ b/contrib/jpg_group_leader.lua
@@ -186,7 +186,7 @@ dt.register_event(MODULE .. "_collect", "shortcut",
     local images = dt.collection
     make_existing_jpg_group_leader(images)
   end,
-  string.format(_("make jpg group leader for %s", _("collection")))
+  _("make jpg group leader for collection")
 )
 
 dt.register_event(MODULE .. "_select", "shortcut",
@@ -194,7 +194,7 @@ dt.register_event(MODULE .. "_select", "shortcut",
     local images = dt.gui.selection()
     make_existing_jpg_group_leader(images)
   end,
-  string.format(_("make jpg group leader for %s", _("selection")))
+  _("make jpg group leader for selection")
 )
 
 return script_data

--- a/official/apply_camera_style.lua
+++ b/official/apply_camera_style.lua
@@ -463,18 +463,16 @@ script_data.destroy = destroy
 -- E V E N T S
 -- - - - - - - - - - - - - - - - - - - - - - - - 
 
-local shortcut_string = _("apply darktable camera styles to %s")
-
 dt.register_event(MODULE, "shortcut",
   function(event, shortcut)
     apply_camera_style(true)
-  end, string.format(shortcut_string, _("collection"))
+  end, _("apply darktable camera styles to collection")
 )
 
 dt.register_event(MODULE, "shortcut",
   function(event, shortcut)
     apply_camera_style(false)
-  end, string.format(shortcut_string, _("selection"))
+  end, _("apply darktable camera styles to selection")
 )
 
 dt.register_event(MODULE, "post-import-image",


### PR DESCRIPTION
changed this construct `string.format(shortcut_string, _("collection"))` to `_("apply darktable camera styles to collection")` as the bare words `collection` and `selection` are translated in other contexts with capitalization. `contrib/hif_group_leader` and `contrib/jpg_group_leader` also use the same construct so it's fixed there also.