### PR TITLE
Fixed variable substitutions

### DIFF
--- a/lib/dtutils/string.lua
+++ b/lib/dtutils/string.lua
@@ -746,7 +746,7 @@ function dtutils_string.build_substitute_list(image, sequence, variable_string, 
 
   local version_multi = #image:get_group_members() > 1 and image.version or ""
 
-  local replacements = {image.film.path,                       -- ROLL.NAME
+  local replacements = {dtutils_string.get_basename(image.film.path),-- ROLL.NAME
                         image.path,                            -- FILE.FOLDER
                         dtutils_string.get_basename(image.filename),-- FILE.NAME
                         dtutils_string.get_filetype(image.filename),-- FILE.EXTENSION

--- a/lib/dtutils/string.lua
+++ b/lib/dtutils/string.lua
@@ -744,7 +744,7 @@ function dtutils_string.build_substitute_list(image, sequence, variable_string, 
       string.match(image.exif_datetime_taken, "(%d+):(%d+):(%d+) (%d+):(%d+):(%d+)$")
   end
 
-  local version_multi = #image:get_group_members() > 1 and image.version or ""
+  local version_multi = #image:get_group_members() > 1 and image.duplicate_index or ""
 
   local replacements = {dtutils_string.get_basename(image.film.path),-- ROLL.NAME
                         image.path,                            -- FILE.FOLDER

--- a/lib/dtutils/string.lua
+++ b/lib/dtutils/string.lua
@@ -748,7 +748,7 @@ function dtutils_string.build_substitute_list(image, sequence, variable_string, 
 
   local replacements = {image.film.path,                       -- ROLL.NAME
                         image.path,                            -- FILE.FOLDER
-                        image.filename,                        -- FILE.NAME
+                        dtutils_string.get_basename(image.filename),-- FILE.NAME
                         dtutils_string.get_filetype(image.filename),-- FILE.EXTENSION
                         image.id,                              -- ID
                         image.duplicate_index,                 -- VERSION


### PR DESCRIPTION
According to comments, https://docs.darktable.org/usermanual/4.6/en/special-topics/variables/ and/or DT source code: `$(FILE.NAME)` and `$(ROLL.NAME)` should both be basenames.

Fixed error in `build_substitute_list` for images with duplicates, as the code referred to an undefined `version` property.