### PR TITLE
Add change encoding to bat file for dtutils/system.lua windows_command

### DIFF
--- a/lib/dtutils/system.lua
+++ b/lib/dtutils/system.lua
@@ -87,7 +87,13 @@ function dtutils_system.windows_command(command)
   if file then
     dt.print_log("opened file")
     command = string.gsub(command, "%%", "%%%%") -- escape % from windows shell
-    file:write(command)
+    file:write("@echo off\n")
+    file:write('for /f "tokens=2 delims=:." %%x in (\'chcp\') do set cp=%%x\n')
+    file:write("chcp 65001>nul\n") -- change the encoding of the terminal to handle non-english characters in path
+    file:write("\n")
+    file:write(command .. "\n")
+    file:write("\n") 
+    file:write("chcp %%cp%%>nul\n")
     file:close()
 
     result = dt.control.execute(fname)


### PR DESCRIPTION
This should fix #548 

The change adds commands to change the encoding of the terminal that is spawned when executing the bat file.

I tested the OpenInExplorer script with paths with accentuated characters, the update lua scripts command and the external editor command. So far they all work as expected.

Thanks!