### PR TITLE
Update x-touch.lua switch colorequal tab

### DIFF
--- a/examples/x-touch.lua
+++ b/examples/x-touch.lua
@@ -49,6 +49,8 @@ midi:A#-1=iop/toneequal;focus
 midi:B-1=iop/colorbalancergb;focus
 midi:C0=iop/channelmixerrgb;focus
 midi:C#0=iop/colorequal;focus
+midi:D0=iop/colorequal/page;previous
+midi:D#0=iop/colorequal/page;next
 ]]
 
 local dt = require "darktable"


### PR DESCRIPTION
added recommended additional shortcuts to switch between hue, saturation and brightness tabs: midi:D0=iop/colorequal/page;previous
midi:D#0=iop/colorequal/page;next