### PR TITLE
Align sequence tooltip with code.

### DIFF
--- a/lib/dtutils/string.lua
+++ b/lib/dtutils/string.lua
@@ -877,7 +877,7 @@ function dtutils_string.get_substitution_tooltip()
           _("$(VERSION.NAME) - version name from metadata"),
           _("$(DARKTABLE.VERSION) - current darktable version"),
           -- _("$(DARKTABLE.NAME) - darktable name"),  -- not implemented
-          _("$(SEQUENCE[m,n]) - sequence number, m: start number, n: number of digits"),
+          _("$(SEQUENCE[n,m]) - sequence number, n: number of digits, m: start number"),
           _("$(WIDTH.SENSOR) - image sensor width"),
           _("$(HEIGHT.SENSOR) - image sensor height"),
           _("$(WIDTH.RAW) - RAW image width"),

--- a/lib/dtutils/string.lua
+++ b/lib/dtutils/string.lua
@@ -877,7 +877,7 @@ function dtutils_string.get_substitution_tooltip()
           _("$(VERSION.NAME) - version name from metadata"),
           _("$(DARKTABLE.VERSION) - current darktable version"),
           -- _("$(DARKTABLE.NAME) - darktable name"),  -- not implemented
-          _("$(SEQUENCE[n,m]) - sequence number, n: number of digits, m: start number"),
+          _("$(SEQUENCE[m,n]) - sequence number, m: start number, n: number of digits"),
           _("$(WIDTH.SENSOR) - image sensor width"),
           _("$(HEIGHT.SENSOR) - image sensor height"),
           _("$(WIDTH.RAW) - RAW image width"),

--- a/lib/dtutils/string.lua
+++ b/lib/dtutils/string.lua
@@ -994,7 +994,7 @@ local function treat(var_string)
     log.msg(log.info, "ret_val is " .. ret_val)
 
   elseif string.match(var_string, "SEQUENCE%[") then
-    local start, width = string.match(var_string, "(%d+),(%d)")
+    local width, start = string.match(var_string, "(%d+),(%d)")
     local seq_val = tonumber(substitutes[var])
     local pat = "%0" .. width .. "d"
     substitutes[var_string] = string.format(pat, start + (seq_val - 1))


### PR DESCRIPTION
I believe the tooltip is not aligned with the code. 

Based on [this](https://github.com/darktable-org/lua-scripts/blob/master/lib/dtutils/string.lua#L997) we expect the start number first and the width second. I didn't change the string match pattern, it's not clear to me if we want it the other way around of not.