### PR TITLE
fix RL_out_sharp crash

### DIFF
--- a/contrib/RL_out_sharp.lua
+++ b/contrib/RL_out_sharp.lua
@@ -106,7 +106,7 @@ local function preserve_metadata(original, sharpened)
   if exiftool then
     dtsys.external_command("exiftool -overwrite_original_in_place -tagsFromFile " .. original .. " " .. sharpened)
   else
-    dt.print_log(MODULE .. " exiftool not found,  metadata not preserved")
+    dt.print_log(MODULE_NAME .. " exiftool not found,  metadata not preserved")
   end
 end
 


### PR DESCRIPTION
contrib/RL_out_sharp - changed MODULE to MODULE_NAME so that message  would print and script wouldn't crash