### PR TITLE
Fix sequence string substitution variable to accept starting number > 9

### DIFF
--- a/lib/dtutils/string.lua
+++ b/lib/dtutils/string.lua
@@ -1011,7 +1011,7 @@ local function treat(var_string)
     log.msg(log.info, "ret_val is " .. ret_val)
 
   elseif string.match(var_string, "SEQUENCE%[") then
-    local width, start = string.match(var_string, "(%d+),(%d)")
+    local width, start = string.match(var_string, "(%d+),(%d+)")
     local seq_val = tonumber(substitutes[var])
     local pat = "%0" .. width .. "d"
     substitutes[var_string] = string.format(pat, start + (seq_val - 1))


### PR DESCRIPTION
Fixed `$(SEQUENCE[n,m])` to accept `m` larger than 9

Fixes https://github.com/darktable-org/darktable/issues/19639