### PR TITLE
official/regenerate_thumbnails - add a script to fix skull thumbnails

### DIFF
--- a/official/regenerate_thumbnails.lua
+++ b/official/regenerate_thumbnails.lua
@@ -181,6 +181,9 @@ local function generate_thumbnails(images)
     image:drop_cache()
     image:generate_cache(true, 1, 3)
     if has_job then
+      if not rt.job.valid then
+        return
+      end
       if count % 10 == 0 then
         rt.job.percent = count / #images
       end


### PR DESCRIPTION
add a script to fix skull thumbnails by dropping the cache for the image and regenerating it.  Adds a button to the actions on selected images module.  Also has a shortcut to apply the script by hovering and triggering the shortcut.

Fixes https://github.com/darktable-org/darktable/issues/19696