### PR TITLE
fix dtutils_system.external_command ignoring bad return code on Windows

### DIFF
--- a/lib/dtutils/system.lua
+++ b/lib/dtutils/system.lua
@@ -90,9 +90,11 @@ function dtutils_system.windows_command(command)
     file:write('for /f "tokens=2 delims=:." %%x in (\'chcp\') do set cp=%%x\n')
     file:write("chcp 65001>nul\n") -- change the encoding of the terminal to handle non-english characters in path
     file:write("\n")
+    file:write("set COMMAND_RC=%ERRORLEVEL%")
     file:write(command .. "\n")
     file:write("\n") 
     file:write("chcp %cp%>nul\n")
+    file:write("exit /b %COMMAND_RC%") -- otherwise, when the real command fails, script will still return "good" error code of chcp
     file:close()
 
     result = dt.control.execute(fname)


### PR DESCRIPTION
On Windows, external_command calls windows_command which prepares a bat file with the command, surrounded with code page saving/restoration. If the "real" command fails, its error return code does not get anywhere and 0 is always returned, because the last line is a chcp call which always succeeds. This breaks error handling logic in scripts, e.g. enfuseAdvanced, where they think everything went fine when it didn't.