### PR TITLE
enable reset in rename_images.lua

### DIFF
--- a/contrib/rename_images.lua
+++ b/contrib/rename_images.lua
@@ -96,11 +96,6 @@ local function stop_job(job)
   job.valid = false
 end
 
-local function reset_callback()
-  rename.widgets.pattern.text = ""
-  dt.preferences.write(MODULE_NAME, "pattern", "string", rename.widgets.pattern.text)
-end
-
 local function install_module()
   if not rename.module_installed then
     dt.register_lib(
@@ -110,9 +105,6 @@ local function install_module()
       true,
       {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER",700}},
       dt.new_widget("box"){
-        reset_callback = function (self) 
-          reset_callback()
-        end,
         orientation = "vertical",
         rename.widgets.pattern,
         rename.widgets.button,
@@ -201,7 +193,10 @@ end
 rename.widgets.pattern = dt.new_widget("entry"){
   tooltip = ds.get_substitution_tooltip(),
   placeholder = _("enter pattern") .. "$(FILE_FOLDER)/$(FILE_NAME)",
-  text = ""
+  text = "",
+  reset_callback = function(self)
+    self.text = ""
+  end
 }
 
 local pattern_pref = dt.preferences.read(MODULE_NAME, "pattern", "string")

--- a/contrib/rename_images.lua
+++ b/contrib/rename_images.lua
@@ -196,6 +196,7 @@ rename.widgets.pattern = dt.new_widget("entry"){
   text = "",
   reset_callback = function(self)
     self.text = ""
+    dt.preferences.write(MODULE_NAME, "pattern", "string", self.text)
   end
 }
 

--- a/contrib/rename_images.lua
+++ b/contrib/rename_images.lua
@@ -96,6 +96,11 @@ local function stop_job(job)
   job.valid = false
 end
 
+local function reset_callback()
+  rename.widgets.pattern.text = ""
+  dt.preferences.write(MODULE_NAME, "pattern", "string", rename.widgets.pattern.text)
+end
+
 local function install_module()
   if not rename.module_installed then
     dt.register_lib(
@@ -105,6 +110,9 @@ local function install_module()
       true,
       {[dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_RIGHT_CENTER",700}},
       dt.new_widget("box"){
+        reset_callback = function (self) 
+          reset_callback()
+        end,
         orientation = "vertical",
         rename.widgets.pattern,
         rename.widgets.button,
@@ -185,9 +193,6 @@ local function do_rename(images)
   end
 end
 
-local function reset_callback()
-  rename.widgets.pattern.text = ""
-end
 
 -- - - - - - - - - - - - - - - - - - - - - - - -
 -- W I D G E T S


### PR DESCRIPTION
This PR enables the reset function in rename_images.lua. 
Clicking the reset button clears the entry field and the hidden preference.

Closes #635 