### PR TITLE
fix wrong month in EXIF.MONTH.LONG and EXIF_MONTH.SHORT when no exif date available in image

### DIFF
--- a/lib/dtutils/string.lua
+++ b/lib/dtutils/string.lua
@@ -793,6 +793,7 @@ function dtutils_string.build_substitute_list(image, sequence, variable_string, 
         string.match(datetime_taken, "(%d+):(%d+):(%d+) (%d+):(%d+):(%d+)$")
     end    
   else
+    log.msg(log.warn, "no capture datetime found in EXIF data")
     emon_long, emon_short, eyear, emon, eday, ehour, emin, esec, emsec = ""
   end
 

--- a/lib/dtutils/string.lua
+++ b/lib/dtutils/string.lua
@@ -774,6 +774,7 @@ function dtutils_string.build_substitute_list(image, sequence, variable_string, 
   local labels = get_colorlabels(image)
 
   local datetime_taken = ""
+  local emon_long, emon_short
   local use_millisecs = false
   if dt.preferences.read("darktable", "lighttable/ui/milliseconds", "bool") and is_api_9_1 then
     use_millisecs = true
@@ -781,12 +782,16 @@ function dtutils_string.build_substitute_list(image, sequence, variable_string, 
 
   if image.exif_datetime_taken and image.exif_datetime_taken ~= "" then
     datetime_taken = image.exif_datetime_taken
+    emon_long = os.date("%B", exiftime2systime(datetime_taken))
+    emon_short = os.date("%b", exiftime2systime(datetime_taken))
   else
     if use_millisecs then
       datetime_taken = "0000:00:00 00:00:00.0"
     else
       datetime_taken = "0000:00:00 00:00:00"
     end
+    emon_long = _("unknown")
+    emon_short = "???"
   end
 
   local eyear, emon, eday, ehour, emin, esec, emsec
@@ -840,8 +845,8 @@ function dtutils_string.build_substitute_list(image, sequence, variable_string, 
                         eyear,                                 -- EXIF.YEAR
                         string.sub(eyear, 3),                  -- EXIF.YEAR.SHORT
                         emon,                                  -- EXIF.MONTH
-                        os.date("%B", exiftime2systime(datetime_taken)), -- EXIF.MONTH.LONG
-                        os.date("%b", exiftime2systime(datetime_taken)), -- EXIF.MONTH.SHORT
+                        emon_long,                             -- EXIF.MONTH.LONG
+                        emon_short,                            -- EXIF.MONTH.SHORT
                         eday,                                  -- EXIF.DAY
                         ehour,                                 -- EXIF.HOUR
                         "",                                    -- EXIF.HOUR.AMPM

--- a/lib/dtutils/string.lua
+++ b/lib/dtutils/string.lua
@@ -773,8 +773,8 @@ function dtutils_string.build_substitute_list(image, sequence, variable_string, 
 
   local labels = get_colorlabels(image)
 
-  local datetime_taken = ""
   local emon_long, emon_short
+  local eyear, emon, eday, ehour, emin, esec, emsec
   local use_millisecs = false
   if dt.preferences.read("darktable", "lighttable/ui/milliseconds", "bool") and is_api_9_1 then
     use_millisecs = true
@@ -784,26 +784,17 @@ function dtutils_string.build_substitute_list(image, sequence, variable_string, 
     datetime_taken = image.exif_datetime_taken
     emon_long = os.date("%B", exiftime2systime(datetime_taken))
     emon_short = os.date("%b", exiftime2systime(datetime_taken))
-  else
     if use_millisecs then
-      datetime_taken = "0000:00:00 00:00:00.0"
+      eyear, emon, eday, ehour, emin, esec, emsec = 
+        string.match(datetime_taken, "(%d+):(%d+):(%d+) (%d+):(%d+):(%d+)%.(%d+)$")
     else
-      datetime_taken = "0000:00:00 00:00:00"
-    end
-    emon_long = _("unknown")
-    emon_short = "???"
-  end
-
-  local eyear, emon, eday, ehour, emin, esec, emsec
-  if use_millisecs then
-    eyear, emon, eday, ehour, emin, esec, emsec = 
-      string.match(datetime_taken, "(%d+):(%d+):(%d+) (%d+):(%d+):(%d+)%.(%d+)$")
+      emsec = "0"
+      eyear, emon, eday, ehour, emin, esec = 
+        string.match(datetime_taken, "(%d+):(%d+):(%d+) (%d+):(%d+):(%d+)$")
+    end    
   else
-    emsec = "0"
-    eyear, emon, eday, ehour, emin, esec = 
-      string.match(datetime_taken, "(%d+):(%d+):(%d+) (%d+):(%d+):(%d+)$")
+    emon_long, emon_short, eyear, emon, eday, ehour, emin, esec, emsec = ""
   end
-
 
   local version_multi = #image:get_group_members() > 1 and image.duplicate_index or ""
 
@@ -843,7 +834,7 @@ function dtutils_string.build_substitute_list(image, sequence, variable_string, 
                         string.format("%02d", datetime.sec),   -- SECOND
                         0,                                     -- MSEC
                         eyear,                                 -- EXIF.YEAR
-                        string.sub(eyear, 3),                  -- EXIF.YEAR.SHORT
+                        (eyear ~= nil) and string.sub(eyear, 3) or "", -- EXIF.YEAR.SHORT
                         emon,                                  -- EXIF.MONTH
                         emon_long,                             -- EXIF.MONTH.LONG
                         emon_short,                            -- EXIF.MONTH.SHORT

--- a/lib/dtutils/string.lua
+++ b/lib/dtutils/string.lua
@@ -781,9 +781,8 @@ function dtutils_string.build_substitute_list(image, sequence, variable_string, 
   end
 
   if image.exif_datetime_taken and image.exif_datetime_taken ~= "" then
-    datetime_taken = image.exif_datetime_taken
-    emon_long = os.date("%B", exiftime2systime(datetime_taken))
-    emon_short = os.date("%b", exiftime2systime(datetime_taken))
+    emon_long = os.date("%B", exiftime2systime(image.exif_datetime_taken))
+    emon_short = os.date("%b", exiftime2systime(image.exif_datetime_taken))
     if use_millisecs then
       eyear, emon, eday, ehour, emin, esec, emsec = 
         string.match(datetime_taken, "(%d+):(%d+):(%d+) (%d+):(%d+):(%d+)%.(%d+)$")
@@ -793,7 +792,7 @@ function dtutils_string.build_substitute_list(image, sequence, variable_string, 
         string.match(datetime_taken, "(%d+):(%d+):(%d+) (%d+):(%d+):(%d+)$")
     end    
   else
-    log.msg(log.warn, "no capture datetime found in EXIF data")
+    log.msg(log.warn, "no capture date and time found in EXIF data")
     emon_long, emon_short, eyear, emon, eday, ehour, emin, esec, emsec = ""
   end
 


### PR DESCRIPTION
PR #594 fixed a bug in rename_images.lua with images that have no EXIF datetime. However, the fix (setting datetime_taken to 0000.00.00) does not work on Windows, because the date is smaller than what can be represented on this platform. 
In addition, on linux the date 0000.00.00 results in EXIF.MONTH.LONG and EXIF.MONTH.SHORT as "November" and "Nov", respectively.
In this PR I propose to skip the calculation of EXIF.MONTH.LONG and .SHORT for images without a date, and set them as follows:
EXIF.MONTH.LONG = "unknown"
EXIF.MONTH.SHORT = "???"

closes issue https://github.com/darktable-org/lua-scripts/issues/627
