### PR TITLE
fix: autostyle deadlock on import and deprecated API removal for Windows

### DIFF
--- a/contrib/autostyle.lua
+++ b/contrib/autostyle.lua
@@ -71,10 +71,10 @@ script_data.show = nil -- only required for libs since the destroy_method only h
 local function get_stdout(cmd)
   -- Open the command, for reading
   local fd = assert(io.popen(cmd, 'r'))
-  darktable.control.read(fd)
+  -- darktable.control.read(fd)
   -- slurp the whole file
   local data = assert(fd:read('*a'))
-
+  -- darktable.print(string.format(_("data is %s"), data))
   fd:close()
   -- Replace carriage returns and linefeeds with spaces
   data = string.gsub(data, '[\n\r]+', ' ')
@@ -87,7 +87,7 @@ end
 
 -- Retrieve the attribute through exiftool
 local function exiftool_attribute(path, attr)
-  local cmd = "exiftool -" .. attr .. " '" .. path .. "'";
+  local cmd = "exiftool -" .. attr .. ' "' .. path .. '"';
   local exifresult = get_stdout(cmd)
   local attribute = string.match(exifresult, ": (.*)")
   if (attribute == nil) then
@@ -165,7 +165,10 @@ end
 
 -- Receive the event triggered
 local function autostyle_apply_one_image_event(event,image)
-  autostyle_apply_one_image(image)
+  darktable.control.dispatch(function()
+    darktable.control.sleep(500)
+    autostyle_apply_one_image(image)
+  end)
 end
 
 local function autostyle_apply(shortcut)


### PR DESCRIPTION
Problems:

1. Calling darktable.styles.apply() directly inside the post-import-image callback causes darktable to hang/deadlock.

2. darktable.control.read() has been removed from the Lua API in recent versions (field "read" not found for type dt_lua_singleton_control), causing the script to fail on startup.

3. Windows cmd.exe only recognizes double quotes while exiftool_attribute() use single quotes for path. 

Fix:

- Wrap the post-import-image callback logic in darktable.control.dispatch() + darktable.control.sleep(500) so that style application runs asynchronously in a background thread after the import pipeline has finished. This avoids the deadlock while still supporting both single-image and batch imports.

- Remove the darktable.control.read(fd) call from get_stdout(). This function was only used to yield the Lua thread while waiting for I/O — it did not perform any data reading itself (fd:read('*a') handles that). Since the entire exiftool call now runs inside a dispatched background task, blocking the background thread is acceptable and does not freeze the UI.

- Change path quoting from single to double quotes.

Tested on darktable 5.4.1 / Windows with Canon CR3 files.