### PR TITLE
Missing argument in group_persistence.lua

### DIFF
--- a/official/group_persistence.lua
+++ b/official/group_persistence.lua
@@ -446,7 +446,7 @@ local function build_group(leader)
 
   for _, image in ipairs(leader:get_group_members()) do
     if not has_group_tag(image) then
-      add_to_group(image)
+      add_to_group(image, leader)
     end
   end
 end


### PR DESCRIPTION
`add_to_group` was still failing as the leader was not provided as second argument.