### PR TITLE
script_manager - fix system scripts detection

### DIFF
--- a/tools/script_manager.lua
+++ b/tools/script_manager.lua
@@ -70,7 +70,7 @@ local scripts_path = info.source:sub(2)
 -- assume user based
 local system_based = false
 
-if string.match(scripts_path, dt.configuration.data_dir) then
+if string.match(scripts_path, ds.sanitize_lua(dt.configuration.data_dir)) then
   log.msg(log.info, "script_manager using system based scripts")
   system_based = true
 end


### PR DESCRIPTION
If the darktable install path has characters that are significant in Lua pattern matching then detection of whether the bundled lua-scripts are being used or the user installed fails.

Sanitized the install directory path to fix it.