### PR TITLE
Fix lua 5.5 incompatibilities

### DIFF
--- a/contrib/HDRMerge.lua
+++ b/contrib/HDRMerge.lua
@@ -277,9 +277,9 @@ local function main()
     local set_tag = GUI.Target.add_tags.text
     if set_tag ~= nil then -- add additional user-specified tags
       for tag in string.gmatch(set_tag, '[^,]+') do
-        tag = CleanSpaces(tag)
-        tag = dt.tags.create(tag)
-        dt.tags.attach(tag, imported) 
+        local cleaned_tag = CleanSpaces(tag)
+        cleaned_tag = dt.tags.create(cleaned_tag)
+        dt.tags.attach(cleaned_tag, imported)
       end
     end
     dt.print(_('HDRMerge completed successfully'))

--- a/contrib/enfuseAdvanced.lua
+++ b/contrib/enfuseAdvanced.lua
@@ -527,9 +527,9 @@ local function main(storage, image_table, extra_data)
             local set_tag = GUI.Target.add_tags.text
             if set_tag ~= nil then --add additional user-specified tags
                 for tag in string.gmatch(set_tag, '[^,]+') do
-                    tag = CleanSpaces(tag)
-                    tag = dt.tags.create(tag)
-                    dt.tags.attach(tag, imported) 
+                    local cleaned_tag = CleanSpaces(tag)
+                    cleaned_tag = dt.tags.create(cleaned_tag)
+                    dt.tags.attach(cleaned_tag, imported)
                 end
             end
         end

--- a/contrib/face_recognition.lua
+++ b/contrib/face_recognition.lua
@@ -311,25 +311,26 @@ local function face_recognition ()
             if ignoreByTag (img, ignoreTags) then
               dt.print_log("Face recognition: Ignoring image with ID " .. img.id)
             else
+              local tag_name = t
               -- Check of unrecognized unknown_person
-              if t == "unknown_person" then
-                t = unknownTag
+              if tag_name == "unknown_person" then
+                tag_name = unknownTag
               end
               -- Check of unrecognized no_persons_found
-              if t == "no_persons_found" then
-                t = nonpersonsfoundTag
+              if tag_name == "no_persons_found" then
+                tag_name = nonpersonsfoundTag
               end
-              if t ~= "" and t ~= nil then
-                if categoryTagString ~= "" and t ~= nonpersonsfoundTag then
-                  t = categoryTagString .. "|" .. t
+              if tag_name ~= "" and tag_name ~= nil then
+                if categoryTagString ~= "" and tag_name ~= nonpersonsfoundTag then
+                  tag_name = categoryTagString .. "|" .. tag_name
                 end                  
-                dt.print_log ("ImgId:" .. img.id .. " Tag:".. t)
+                dt.print_log ("ImgId:" .. img.id .. " Tag:".. tag_name)
                 -- Create tag if it does not exist
-                if tags_list[t] == nil then
-                  tag = dt.tags.create (t)
-                  tags_list[t] = tag
+                if tags_list[tag_name] == nil then
+                  tag = dt.tags.create (tag_name)
+                  tags_list[tag_name] = tag
                 else
-                  tag = tags_list[t]
+                  tag = tags_list[tag_name]
                 end
                 img:attach_tag (tag)
               end

--- a/contrib/gimp.lua
+++ b/contrib/gimp.lua
@@ -142,8 +142,8 @@ local function gimp_edit(storage, image_table, extra_data) --finalize
   img_list = ""
 
   for _,exp_img in pairs(image_table) do
-    exp_img = df.sanitize_filename(exp_img)
-    img_list = img_list ..exp_img.. " "
+    local sanitized = df.sanitize_filename(exp_img)
+    img_list = img_list ..sanitized.. " "
   end
 
   dt.print(_("launching GIMP..."))

--- a/contrib/image_stack.lua
+++ b/contrib/image_stack.lua
@@ -323,8 +323,8 @@ local function cleanup(img_list)
   dt.print_log("image list is " .. img_list)
   files = du.split(img_list, " ")
   for _,f in ipairs(files) do
-    f = string.gsub(f, '[\'\"]', "")
-    os.remove(f)
+    local cleaned = string.gsub(f, '[\'\"]', "")
+    os.remove(cleaned)
   end
 end
 

--- a/tools/get_lib_manpages.lua
+++ b/tools/get_lib_manpages.lua
@@ -63,8 +63,8 @@ local output = io.popen("cd "..dt.configuration.config_dir.."/lua/lib ;find . -n
 -- loop through the libraries
 
 for line in output:lines() do
-  line = string.gsub(line, "/", ".")
-  local lib_name = line:sub(3,-5)
+  local cleaned_line = string.gsub(line, "/", ".")
+  local lib_name = cleaned_line:sub(3,-5)
   if lib_name:len() > 2 then
     lib_name = "lib/" .. lib_name
     local lib = require(lib_name)

--- a/tools/get_libdoc.lua
+++ b/tools/get_libdoc.lua
@@ -40,8 +40,8 @@ local output = io.popen("cd "..dt.configuration.config_dir.."/lua/lib ;find . -n
 -- loop through the libraries
 
 for line in output:lines() do
-  line = string.gsub(line, "/", ".")
-  local lib_name = line:sub(3,-5)
+  local cleaned_line = string.gsub(line, "/", ".")
+  local lib_name = cleaned_line:sub(3,-5)
   if lib_name:len() > 2 then
     lib_name = "lib/" .. lib_name
     local lib = require(lib_name)

--- a/tools/script_manager.lua
+++ b/tools/script_manager.lua
@@ -946,7 +946,9 @@ local function install_scripts()
           sm.widgets.folder_selector.selected = i
           break
         end
-        i = i + 1
+        -- Lua 5.5: for loop control variables are read-only. This increment
+        -- was always a no-op since numeric for loops use an internal counter.
+        -- i = i + 1
       end
 
       log.msg(log.debug, "clearing text fields")


### PR DESCRIPTION
With Lua 5.5, for loop control variables are now read-only by default. These changes fix that issue across all the scripts in this repository. Note that these fixes are backwards compatible with Lua 5.4.

The change in tools/script_manager.lua is a little unique. It has this at the end of the for loop:

`i = i + 1`

... where `i` is the for loop control variable. Even in Lua 5.4, this ... didn't do anything. Hypothetically, if the `i` variable was used at a later point in the for loop, that line might have merit, but it's the last line of the for loop. Lua (as far as I can find) has always kept the counter value separate from any manipulation within the loop, so this line is just a no-op, and I'm not entirely sure why it was there. Commenting it out should be safe and will resolve the Lua 5.5 error.

I searched through all the scripts to see if there were any other Lua 5.5 incompatibilities besides modifying the for loop control var inside the loop, and I could not find any.