### PR TITLE
Fix stray "File Not Found" stderr from dir on Windows startup

### DIFF
--- a/tools/script_manager.lua
+++ b/tools/script_manager.lua
@@ -748,7 +748,7 @@ local function scan_scripts(script_dir)
   local find_cmd = "find -L " .. script_dir .. " -name \\*.lua -print | sort"
 
   if dt.configuration.running_os == "windows" then
-    find_cmd = "dir /b/s \"" .. script_dir .. "\\*.lua\" | sort"
+    find_cmd = "dir /b/s \"" .. script_dir .. "\\*.lua\" 2>nul | sort"
   end
 
   log.msg(log.debug, "find command is " .. find_cmd)
@@ -842,7 +842,7 @@ local function scan_repositories()
   local find_cmd = "find -L " .. LUA_DIR .. " -name \\*.git -print | sort"
 
   if dt.configuration.running_os == "windows" then
-    find_cmd = "dir /b/s /a:d " .. LUA_DIR .. PS .. "*.git | sort"
+    find_cmd = "dir /b/s /a:d " .. LUA_DIR .. PS .. "*.git 2>nul | sort"
   end
 
   log.msg(log.debug, "find command is " .. find_cmd)


### PR DESCRIPTION
Fix stray `The system cannot find the path specified.` message printed at darktable startup on Windows when the Lua script directories contain no `.lua` or `.git` entries (typical on a fresh install).

`tools/script_manager.lua` shells out via `io.popen` to scan installed scripts using `cmd.exe`'s `dir` command, but didn't redirect stderr. When the search paths are empty, `dir` writes the error to stderr and it leaks into darktable's terminal.

Two sites fixed by adding `2>nul` before the pipe to `sort`. Linux/macOS `find -L` branches are unaffected - both edits are inside `if dt.configuration.running_os == "windows"` blocks.

Reported in https://github.com/darktable-org/darktable/issues/21240