### PR TITLE
Fix official/extract_burst_roll_images bugs

### DIFF
--- a/official/extract_burst_roll_images.lua
+++ b/official/extract_burst_roll_images.lua
@@ -508,7 +508,7 @@ local function destroy()
   if ebri.select_button then
     dt.gui.libs.select.destroy_selection(MODULE)
   end
-  dt.gui.libs.image.action.destroy_action(MODULE)
+  dt.gui.libs.image.destroy_action(MODULE)
 end
 
 script_data.destroy = destroy

--- a/official/extract_burst_roll_images.lua
+++ b/official/extract_burst_roll_images.lua
@@ -505,6 +505,11 @@ dt.gui.libs.image.register_action(
 local function destroy()
   dt.destroy_event(MODULE, "post-import-film")
   dt.destroy_event(MODULE, "post-import-image")
+  dt.destroy_event(MODULE, "selection-changed")
+  dt.destroy_event(MODULE, "collection-changed")
+  if dt.preferences.read("darktable", "plugins/lighttable/act_on", "bool") then
+    dt.destroy_event(MODULE, "mouse-over-image-changed")
+  end
   if ebri.select_button then
     dt.gui.libs.select.destroy_selection(MODULE)
   end


### PR DESCRIPTION
Fix bugs that prevented extract_burst_roll_images from stopping and starting.

Fixes #685 
Fixes #686 