### PR TITLE
Load user luarc files for users that have their own lua-scripts

### DIFF
--- a/tools/script_manager.lua
+++ b/tools/script_manager.lua
@@ -1388,16 +1388,16 @@ end
 scan_scripts(LUA_DIR)
 log.msg(log.info, "finished processing scripts")
 
-if system_based then
-  -- exec user luarc file if it exists
-  local luarc = loadfile(USER_LUA_DIR .. "rc")
-  if luarc then
-    -- guard against the luarc re-requiring script_manager (see top of file)
-    _G.script_manager_loading = true
-    luarc()
-    _G.script_manager_loading = false
-  end
+-- exec user luarc file if it exists.
+local luarc = loadfile(USER_LUA_DIR .. "rc")
+if luarc then
+  -- guard against the luarc re-requiring script_manager (see top of file)
+  _G.script_manager_loading = true
+  luarc()
+  _G.script_manager_loading = false
+end
 
+if system_based then
   if df.test_file(USER_LUA_DIR, "d") then
     LUA_DIR = USER_LUA_DIR
     scan_scripts(LUA_DIR)


### PR DESCRIPTION
I have the lua-scripts repo cloned in $HOME/.config/darktable/lua

Since darktable a4003bc
(https://github.com/darktable-org/darktable/commit/a4003bcd2c9fc0d45efdd4b4ea93e2aeb3ad8ce6) (PR darktable-org/darktable#20848) removed the direct invocation of the user luarc from lua/init.c, that responsibility moved to script_manager.  But it was only called in the `if system_based` case, so my luarc was never loaded.

This commit pulls the user luarc script loading up so that it runs in both modes.