### PR TITLE
script_manager: use SVG for the start/stop button icons

### DIFF
--- a/data/icons/blank.svg
+++ b/data/icons/blank.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-3 -3 30 30" width="24" height="24"/>

--- a/data/icons/power.svg
+++ b/data/icons/power.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-3 -3 30 30" width="24" height="24">
+  <g fill="none" stroke="#ffffff" stroke-width="2.2" stroke-linecap="round">
+    <path d="M 19.096 3.543 A 11.04 11.04 0 1 1 4.904 3.543"/>
+    <path d="M 12 1.2 L 12 12"/>
+  </g>
+</svg>

--- a/tools/script_manager.lua
+++ b/tools/script_manager.lua
@@ -117,12 +117,12 @@ local LUA_SCRIPT_REPO <const> = "https://github.com/darktable-org/lua-scripts.gi
 
 local LUA_API_VER <const> = "API-" .. dt.configuration.api_version_string
 
--- local POWER_ICON = dt.configuration.config_dir .. "/lua/data/data/icons/power.png"
-local USER_POWER_ICON <const> = dt.configuration.config_dir .. "/lua/data/icons/path20.png"
-local USER_BLANK_ICON <const> = dt.configuration.config_dir .. "/lua/data/icons/blank20.png"
+-- local POWER_ICON = dt.configuration.config_dir .. "/lua/data/data/icons/power.svg"
+local USER_POWER_ICON <const> = dt.configuration.config_dir .. "/lua/data/icons/power.svg"
+local USER_BLANK_ICON <const> = dt.configuration.config_dir .. "/lua/data/icons/blank.svg"
 
-local SYSTEM_POWER_ICON <const> = dt.configuration.data_dir .. "/lua-scripts/data/icons/path20.png"
-local SYSTEM_BLANK_ICON <const> = dt.configuration.data_dir .. "/lua-scripts/data/icons/blank20.png"
+local SYSTEM_POWER_ICON <const> = dt.configuration.data_dir .. "/lua-scripts/data/icons/power.svg"
+local SYSTEM_BLANK_ICON <const> = dt.configuration.data_dir .. "/lua-scripts/data/icons/blank.svg"
 
 local LUA_DIR = USER_LUA_DIR
 local POWER_ICON = USER_POWER_ICON


### PR DESCRIPTION
`path20.png` and `blank20.png` are 20x21 bitmaps, so the start/stop buttons are upscaled and soft on a HiDPI screen and stay 20px whatever the interface font size is. `power.svg` and `blank.svg` render at whatever size darktable asks for.

The geometry comes from `dtgtk_cairo_paint_switch()` so the button reads as darktable's own switch icon. The viewBox carries a margin, since the Lua button sizes itself to its content and has no padding of its own. Stroke width was picked by eye: darktable's switch is drawn at a fixed device-pixel width, which an SVG cannot match at every scale.

The old PNGs are now unreferenced but left in place – happy to drop them here if preferred.

Needs [darktable#22229](https://github.com/darktable-org/darktable/pull/22229). Without it `gtk_image_new_from_file()` hands back a 48x48 pixbuf for a 24px SVG on a scale-2 display and lays it out at 48 logical px, against the PNG's 20.

Written with AI assistance.